### PR TITLE
docs: clarify pnpm package requirements, add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Required for `pnpm package` (signed release builds only)
+# Copy this file to .env and fill in your Apple Developer credentials.
+# You do NOT need this file for development — use `pnpm dev` instead.
+
+# Apple ID used to sign in to App Store Connect for notarization
+APPLE_ID=your@email.com
+
+# App-specific password generated at appleid.apple.com
+# (not your Apple ID login password)
+APPLE_ID_PASSWORD=xxxx-xxxx-xxxx-xxxx
+
+# Your Apple Developer Team ID (found at developer.apple.com/account)
+APPLE_TEAM_ID=XXXXXXXXXX
+
+# Code-signing certificate (.p12) — base64-encoded or a file path
+# CSC_LINK=/path/to/certificate.p12
+# CSC_KEY_PASSWORD=your-certificate-password

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 .env
 .env.*
+!.env.example
 dist-ssr
 *.local
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,20 @@ pnpm install
 pnpm dev
 ```
 
-### Building a distributable
+<br />
+
+## Distribution
+
+`pnpm package` produces a signed, notarized `.dmg`/`.zip` for release. It requires Apple Developer credentials — **most contributors only need `pnpm dev`.**
+
+Create a `.env` file from the provided example and fill in your Apple Developer credentials:
+
+```bash
+cp .env.example .env
+# edit .env with your APPLE_ID, APPLE_ID_PASSWORD, APPLE_TEAM_ID, and certificate details
+```
+
+Then run:
 
 ```bash
 pnpm package


### PR DESCRIPTION
Closes #100

## Summary

- Moves "Building a distributable" out of Getting Started into its own **Distribution** section — makes clear it's a release/maintainer workflow, not a contributor step
- Adds `.env.example` with Apple Developer credential placeholders (`APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `CSC_LINK`)
- Unignores `.env.example` in `.gitignore` (`.env.*` pattern was catching it)

## Test plan

- [ ] Fresh clone → `pnpm dev` still works as documented
- [ ] `.env.example` is tracked by git and visible in the repo
- [ ] README Distribution section reads clearly and links to `.env.example`