### PR TITLE
fix: surface orphaned daemon sessions in Processes view

### DIFF
--- a/docs/decisions/adr-117-orphaned-session-discovery/index.md
+++ b/docs/decisions/adr-117-orphaned-session-discovery/index.md
@@ -1,0 +1,67 @@
+---
+type: adr
+status: accepted
+database:
+  schema:
+    status:
+      type: select
+      options: [todo, in-progress, review, done]
+      default: todo
+    priority:
+      type: select
+      options: [critical, high, medium, low]
+    assignee:
+      type: select
+      options: [opus, sonnet, haiku]
+  defaultView: board
+  groupBy: status
+---
+
+# ADR-117: Orphaned Session Discovery in Processes View
+
+## Context
+
+Manor's terminal-host daemon is intentionally kept alive across app restarts. This means any process running inside a PTY session — including `npm run dev`, build watchers, or test runners — outlives the pane that spawned it.
+
+This becomes a problem when:
+1. A user closes a pane while a long-running process is inside it. The shell exits (SIGHUP), but Node/npm typically ignores SIGHUP and keeps running.
+2. Manor crashes or quits while sessions are alive. The daemon survives (by design), but the restored layout may not include all prior panes.
+
+In both cases the process is still running and consuming resources, but the user has no way to find or kill it from within Manor. The Processes view (ADR-114) already shows port-scanned processes, but it does not surface these "orphaned" daemon sessions explicitly ([orrybaram/manor#115](https://github.com/orrybaram/manor/issues/115)).
+
+## Decision
+
+**Definition**: an orphaned session is one that is alive in the daemon but has no corresponding pane in the currently persisted layout across any workspace.
+
+### 1. `LayoutPersistence.getActiveSessionIds()`
+
+Add a method to `LayoutPersistence` that reads the layout file and returns the `Set<string>` of all `daemonSessionId` values referenced by any pane, across all workspaces and panels. This is a pure read operation — no side effects.
+
+### 2. `processes:list` marks orphaned sessions
+
+In the `processes:list` IPC handler, cross-reference the daemon's session list against `getActiveSessionIds()`. Any session that is alive but not in the active set gets `orphaned: true` in the response. Sessions that have a matching layout pane get `orphaned: false`.
+
+This also fixes a companion bug: the `getDaemonDir()` helper in `processes.ts` was still using the old versioned path (`~/.manor/daemons/{version}/`). Updated to use the fixed path (`~/.manor/daemon/`) introduced in ADR-116.
+
+### 3. "Orphaned Sessions" section in `ProcessesView`
+
+When orphaned sessions exist, a distinct "Orphaned Sessions" section appears below the regular Sessions section in the Processes command-palette view. Each entry shows the session's short ID and last known CWD. A Kill button terminates the session via the existing `processes:killSession` IPC.
+
+Regular Sessions are filtered to show only non-orphaned entries, so each session appears exactly once.
+
+## Consequences
+
+**Better:**
+- Users can see and kill processes that survived pane close or app crash, without leaving Manor.
+- The Processes view is now a complete inventory of what the daemon is running, whether or not there's a visible pane for it.
+
+**Neutral:**
+- Orphaned session detection reads the layout file once per `processes:list` call (synchronous disk read of a small JSON file). No performance impact.
+- Sessions created by the prewarm manager are excluded from `listSessions()` by design (they're filtered in `terminal-host.ts`), so they won't appear as orphaned.
+
+**Out of scope:**
+- "Reopen" / reattach: opening a new pane and wiring it to an existing daemon session requires layout store changes and a new IPC channel. Left as a follow-up.
+
+## Tickets
+
+<div data-type="database" data-path="." data-view="board"></div>

--- a/electron/ipc/processes.ts
+++ b/electron/ipc/processes.ts
@@ -1,18 +1,16 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { ipcMain, app } from "electron";
+import { ipcMain } from "electron";
 import { portlessManager } from "../portless";
 import type { IpcDeps } from "./types";
 import type { ActivePort } from "../backend/types";
+import { LayoutPersistence } from "../terminal-host/layout-persistence";
 
-function getDaemonDir(): string {
-  const version = app.getVersion();
-  return path.join(os.homedir(), ".manor", "daemons", version);
-}
+const DAEMON_DIR = path.join(os.homedir(), ".manor", "daemon");
 
 function getPidPath(): string {
-  return path.join(getDaemonDir(), "terminal-host.pid");
+  return path.join(DAEMON_DIR, "terminal-host.pid");
 }
 
 function readDaemonPid(): number | null {
@@ -38,7 +36,6 @@ export function register(deps: IpcDeps): void {
   const { backend, portScanner, agentHookServer, webviewServer } = deps;
 
   ipcMain.handle("processes:list", async () => {
-    const version = app.getVersion();
     const pid = readDaemonPid();
     const alive = pid !== null ? isDaemonAlive(pid) : false;
 
@@ -48,7 +45,12 @@ export function register(deps: IpcDeps): void {
       { name: "portlessManager", port: portlessManager.proxyPort },
     ];
 
-    let sessions: Array<{ sessionId: string; alive: boolean; cwd: string }> = [];
+    // Get the set of session IDs that are referenced by active layout panes.
+    // Sessions alive in the daemon but NOT in this set are "orphaned" — their
+    // pane was closed or lost, but the processes inside are still running.
+    const activeLayoutSessionIds = new LayoutPersistence().getActiveSessionIds();
+
+    let sessions: Array<{ sessionId: string; alive: boolean; cwd: string | null; orphaned: boolean }> = [];
     if (alive) {
       try {
         const sessionList = await backend.pty.listSessions();
@@ -56,6 +58,7 @@ export function register(deps: IpcDeps): void {
           sessionId: s.sessionId,
           alive: s.alive,
           cwd: s.cwd,
+          orphaned: !activeLayoutSessionIds.has(s.sessionId),
         }));
       } catch {
         // Daemon unreachable — return empty session list
@@ -66,7 +69,7 @@ export function register(deps: IpcDeps): void {
     const ports: ActivePort[] = rawPorts;
 
     return {
-      daemon: { pid, alive, version },
+      daemon: { pid, alive },
       internalServers,
       sessions,
       ports,
@@ -103,20 +106,8 @@ export function register(deps: IpcDeps): void {
       // Process may already be dead
     }
 
-    const daemonDir = getDaemonDir();
-    const socketPath = path.join(daemonDir, "terminal-host.sock");
-    const pidPath = getPidPath();
-
-    try {
-      fs.unlinkSync(socketPath);
-    } catch {
-      // Ignore if already gone
-    }
-    try {
-      fs.unlinkSync(pidPath);
-    } catch {
-      // Ignore if already gone
-    }
+    try { fs.unlinkSync(path.join(DAEMON_DIR, "terminal-host.sock")); } catch { /* already gone */ }
+    try { fs.unlinkSync(getPidPath()); } catch { /* already gone */ }
   });
 
   ipcMain.handle("processes:restartPortless", async () => {

--- a/electron/terminal-host/layout-persistence.test.ts
+++ b/electron/terminal-host/layout-persistence.test.ts
@@ -458,6 +458,77 @@ describe("LayoutPersistence", () => {
     });
   });
 
+  describe("getActiveSessionIds (ADR-117)", () => {
+    it("returns empty set when no layout exists", () => {
+      const ids = persistence.getActiveSessionIds();
+      expect(ids.size).toBe(0);
+    });
+
+    it("returns all daemon session IDs from a single workspace", () => {
+      const layout: PersistedLayout = {
+        version: 2,
+        workspaces: [
+          makeV2Workspace(
+            "/project/main",
+            [makeLeafTab("p1", "ds1"), makeLeafTab("p2", "ds2")],
+            "x",
+          ),
+        ],
+      };
+      persistence.save(layout);
+      const ids = persistence.getActiveSessionIds();
+      expect(ids.has("ds1")).toBe(true);
+      expect(ids.has("ds2")).toBe(true);
+      expect(ids.size).toBe(2);
+    });
+
+    it("collects session IDs across multiple workspaces", () => {
+      const layout: PersistedLayout = {
+        version: 2,
+        workspaces: [
+          makeV2Workspace("/project/main", [makeLeafTab("p1", "ds1")], "x"),
+          makeV2Workspace("/project/feature", [makeLeafTab("p2", "ds2")], "y"),
+        ],
+      };
+      persistence.save(layout);
+      const ids = persistence.getActiveSessionIds();
+      expect(ids.has("ds1")).toBe(true);
+      expect(ids.has("ds2")).toBe(true);
+      expect(ids.size).toBe(2);
+    });
+
+    it("collects session IDs from split panes", () => {
+      const layout: PersistedLayout = {
+        version: 2,
+        workspaces: [
+          makeV2Workspace(
+            "/project/main",
+            [makeSplitTab(["p1", "p2"], ["ds1", "ds2"])],
+            "x",
+          ),
+        ],
+      };
+      persistence.save(layout);
+      const ids = persistence.getActiveSessionIds();
+      expect(ids.has("ds1")).toBe(true);
+      expect(ids.has("ds2")).toBe(true);
+      expect(ids.size).toBe(2);
+    });
+
+    it("does not include session IDs absent from the layout", () => {
+      const layout: PersistedLayout = {
+        version: 2,
+        workspaces: [
+          makeV2Workspace("/project/main", [makeLeafTab("p1", "ds1")], "x"),
+        ],
+      };
+      persistence.save(layout);
+      const ids = persistence.getActiveSessionIds();
+      expect(ids.has("ds-orphaned")).toBe(false);
+      expect(ids.size).toBe(1);
+    });
+  });
+
   describe("v1 migration", () => {
     it("migrates v1 layout to v2 on load", () => {
       const tab = makeLeafTab("p1", "ds1");

--- a/electron/terminal-host/layout-persistence.ts
+++ b/electron/terminal-host/layout-persistence.ts
@@ -189,6 +189,26 @@ export class LayoutPersistence {
   }
 
   /**
+   * Return the set of all daemonSessionIds referenced by any pane in the persisted layout.
+   * Used to identify orphaned daemon sessions (alive in daemon but not in any pane).
+   */
+  getActiveSessionIds(): Set<string> {
+    const layout = this.load();
+    const ids = new Set<string>();
+    if (!layout) return ids;
+    for (const workspace of layout.workspaces) {
+      for (const panel of Object.values(workspace.panels)) {
+        for (const tab of panel.tabs) {
+          for (const paneSession of Object.values(tab.paneSessions)) {
+            ids.add(paneSession.daemonSessionId);
+          }
+        }
+      }
+    }
+    return ids;
+  }
+
+  /**
    * Reconcile persisted layout against running daemon sessions.
    *
    * For each pane in the persisted layout:

--- a/src/components/command-palette/ProcessesView.tsx
+++ b/src/components/command-palette/ProcessesView.tsx
@@ -139,6 +139,8 @@ export function ProcessesView() {
 
   const { daemon, internalServers, sessions, ports } = info;
   const hasDeadSessions = sessions.some((s) => !s.alive);
+  const activeSessions = sessions.filter((s) => !s.orphaned);
+  const orphanedSessions = sessions.filter((s) => s.orphaned);
 
   return (
     <>
@@ -262,10 +264,10 @@ export function ProcessesView() {
         <div className={styles.sectionDescription}>
           Each terminal pane runs in its own isolated subprocess
         </div>
-        {sessions.length === 0 ? (
+        {activeSessions.length === 0 ? (
           <div className={styles.empty}>No active sessions</div>
         ) : (
-          sessions.map((session) => {
+          activeSessions.map((session) => {
             const shortId = session.sessionId.slice(0, 8);
             const cwd = session.cwd
               ? session.cwd.split("/").filter(Boolean).pop() ?? session.cwd
@@ -311,6 +313,49 @@ export function ProcessesView() {
           })
         )}
       </Command.Group>
+
+      {/* ── Orphaned Sessions ── */}
+      {orphanedSessions.length > 0 && (
+        <Command.Group heading="Orphaned Sessions" className={styles.group}>
+          <div className={styles.sectionDescription}>
+            Sessions with no matching pane — processes may still be running inside
+          </div>
+          {orphanedSessions.map((session) => {
+            const shortId = session.sessionId.slice(0, 8);
+            const cwd = session.cwd
+              ? session.cwd.split("/").filter(Boolean).pop() ?? session.cwd
+              : null;
+            return (
+              <Command.Item
+                key={session.sessionId}
+                value={`orphaned session ${session.sessionId} ${cwd ?? ""}`}
+                className={styles.item}
+                onSelect={() => {}}
+              >
+                <span className={styles.icon}>
+                  <Terminal size={14} />
+                </span>
+                <span className={styles.label} style={{ opacity: 0.7 }}>
+                  {shortId}
+                  {cwd ? ` — ${cwd}` : ""}
+                </span>
+                <Tooltip label="Kill orphaned session" side="top">
+                  <button
+                    className={styles.processKill}
+                    tabIndex={-1}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void handleKillSession(session.sessionId);
+                    }}
+                  >
+                    <X size={12} />
+                  </button>
+                </Tooltip>
+              </Command.Item>
+            );
+          })}
+        </Command.Group>
+      )}
 
       {/* ── Ports ── */}
       <Command.Group heading="Ports" className={styles.group}>

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -96,7 +96,6 @@ export interface ManorProcessInfo {
   daemon: {
     pid: number | null;
     alive: boolean;
-    version: string;
   };
   internalServers: Array<{
     name: string;
@@ -106,6 +105,8 @@ export interface ManorProcessInfo {
     sessionId: string;
     alive: boolean;
     cwd: string | null;
+    /** True when the session is alive in the daemon but has no matching pane in the layout */
+    orphaned: boolean;
   }>;
   ports: ActivePort[];
 }


### PR DESCRIPTION
Closes orrybaram/manor#115

## Summary
- Add `LayoutPersistence.getActiveSessionIds()` to compute which sessions the current layout references
- In `processes:list`, cross-reference alive daemon sessions against layout session IDs — sessions with no matching pane are marked `orphaned: true`
- Add an "Orphaned Sessions" section to the Processes view (command palette) with a Kill action for each
- Fix `getDaemonDir()` in `processes.ts` to use the fixed daemon path from ADR-116

## ADR
`docs/decisions/adr-117-orphaned-session-discovery/`

## Note
Depends on orrybaram/manor#119 (ADR-116, fixed daemon socket path) for full correctness, but works independently — the daemon dir fix in this PR is sufficient for the Processes view to function.

## Test plan
- [ ] Start `npm run dev` in a pane, close the pane → open Processes view, see "Orphaned Sessions" section with Kill button
- [ ] Kill action removes the session and its child processes
- [ ] No "Orphaned Sessions" section when all daemon sessions have matching panes
- [ ] App crash recovery: daemon sessions from before crash that are not in restored layout appear as orphaned