### PR TITLE
feat: auto-resume active Claude sessions after Manor relaunch

### DIFF
--- a/docs/decisions/adr-118-claude-auto-resume/index.md
+++ b/docs/decisions/adr-118-claude-auto-resume/index.md
@@ -1,0 +1,65 @@
+---
+type: adr
+status: accepted
+database:
+  schema:
+    status:
+      type: select
+      options: [todo, in-progress, review, done]
+      default: todo
+    priority:
+      type: select
+      options: [critical, high, medium, low]
+    assignee:
+      type: select
+      options: [opus, sonnet, haiku]
+  defaultView: board
+  groupBy: status
+---
+
+# ADR-118: Auto-Resume Active Claude Sessions After Manor Relaunch
+
+## Context
+
+When Manor relaunches after quitting (or after a crash/update that replaces the daemon), panes that previously had an active Claude session show an empty shell prompt. There is no indication a task was in progress and no auto-resume. Users have to manually re-run Claude in the correct working directory ([orrybaram/manor#116](https://github.com/orrybaram/manor/issues/116)).
+
+`tasks.json` persists enough state to identify these sessions: tasks with `status: "active"`, a known `paneId`, a valid `agentCommand`, and no prior `resumedAt` timestamp.
+
+**What's covered:**
+- Session was cold/fresh-restored (daemon replaced or crashed): pane is visible, Claude is not running → auto-resume fires
+- Session received a warm restore (same-version restart, Claude still running): `snapshot` is non-null → auto-resume does not fire
+
+**What's out of scope:**
+- Tasks with no `agentCommand` stored (tasks created before `agentCommand` was persisted in ADR-066)
+
+## Decision
+
+In `useTerminalLifecycle`, after `create()` resolves for a cold or fresh restore (where `result.snapshot === null` and no pending startup command is queued):
+
+1. Fetch active tasks via the existing `tasks:getAll` IPC with `{ status: "active" }`.
+2. Find a task whose `paneId` matches the current pane, `agentCommand` is set, and `resumedAt` is null.
+3. Mark the task `resumedAt: <now>` immediately to prevent double-launch on re-mount.
+4. Wait for the shell's first CWD event (OSC 7 from precmd hook), then write `agentCommand + "\n"` to the PTY. Fall back to a 3 s timeout if no CWD event arrives (same pattern used for pending startup commands).
+
+The `resumedAt` field is added to `TaskInfo` as a nullable string. It is set on auto-resume and never cleared, so a task only auto-resumes once even if the pane is unmounted and remounted.
+
+### Why renderer-side?
+
+The reconcile result (warm/cold/fresh) is only known in the renderer after `create()` resolves. Putting the auto-resume logic here avoids a new IPC round-trip to communicate restore type back to the main process, and reuses the existing CWD-wait pattern already in `useTerminalLifecycle`.
+
+## Consequences
+
+**Better:**
+- After a crash or version upgrade, Claude restarts automatically in the correct pane and CWD without user intervention.
+- `resumedAt` provides an audit trail of when auto-resume fired for a given task.
+
+**Neutral:**
+- Warm restores (same-version restart, Claude still running) are unaffected — `snapshot` being non-null short-circuits the auto-resume check.
+- Prewarmed sessions for new tasks are unaffected — they set `pendingCmd`, which takes priority over auto-resume.
+
+**Limitations:**
+- Tasks with `agentCommand: null` (created before that field was stored) cannot be auto-resumed. The user must relaunch manually.
+
+## Tickets
+
+<div data-type="database" data-path="." data-view="board"></div>

--- a/electron/task-persistence.test.ts
+++ b/electron/task-persistence.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as crypto from "node:crypto";
+import { TaskManager } from "./task-persistence";
+import type { TaskInfo } from "./task-persistence";
+
+describe("TaskManager", () => {
+  let tmpDir: string;
+  let manager: TaskManager;
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `manor-task-test-${crypto.randomUUID()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    manager = new TaskManager(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeTask(
+    overrides: Partial<Omit<TaskInfo, "id" | "createdAt" | "updatedAt" | "activatedAt">> = {},
+  ): TaskInfo {
+    return manager.createTask({
+      agentSessionId: `session-${crypto.randomUUID()}`,
+      name: "Test task",
+      status: "active",
+      completedAt: null,
+      projectId: null,
+      projectName: null,
+      workspacePath: "/project/main",
+      cwd: "/project/main",
+      agentKind: "claude",
+      agentCommand: "claude",
+      paneId: `pane-${crypto.randomUUID()}`,
+      lastAgentStatus: null,
+      resumedAt: null,
+      ...overrides,
+    });
+  }
+
+  describe("resumedAt field (ADR-118)", () => {
+    it("defaults to null when a task is created", () => {
+      const task = makeTask();
+      expect(task.resumedAt).toBeNull();
+    });
+
+    it("can be set via updateTask", () => {
+      const task = makeTask();
+      const now = new Date().toISOString();
+      const updated = manager.updateTask(task.id, { resumedAt: now });
+      expect(updated).not.toBeNull();
+      expect(updated!.resumedAt).toBe(now);
+    });
+
+    it("is preserved across save/load cycles", async () => {
+      const task = makeTask();
+      const now = new Date().toISOString();
+      manager.updateTask(task.id, { resumedAt: now });
+
+      // Wait for the debounced save
+      await new Promise((r) => setTimeout(r, 600));
+
+      // Reload from disk
+      const freshManager = new TaskManager(tmpDir);
+      const loaded = freshManager.getTaskBySessionId(task.agentSessionId);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.resumedAt).toBe(now);
+    });
+
+    it("does not affect status filtering — active tasks with resumedAt are still returned", () => {
+      const task1 = makeTask({ resumedAt: new Date().toISOString() });
+      const task2 = makeTask({ resumedAt: null });
+      makeTask({ status: "completed", resumedAt: null });
+
+      const active = manager.getAllTasks({ status: "active" });
+      const ids = active.map((t) => t.id);
+
+      expect(ids).toContain(task1.id);
+      expect(ids).toContain(task2.id);
+      expect(active).toHaveLength(2);
+    });
+
+    it("can be queried to find tasks that have not yet been resumed", () => {
+      const resumed = makeTask({ resumedAt: new Date().toISOString() });
+      const notResumed = makeTask({ resumedAt: null });
+
+      const active = manager.getAllTasks({ status: "active" });
+      const needResume = active.filter((t) => !t.resumedAt);
+
+      expect(needResume.map((t) => t.id)).toContain(notResumed.id);
+      expect(needResume.map((t) => t.id)).not.toContain(resumed.id);
+    });
+  });
+});

--- a/electron/task-persistence.ts
+++ b/electron/task-persistence.ts
@@ -27,6 +27,8 @@ export interface TaskInfo {
   agentCommand: string | null;
   paneId: string | null;
   lastAgentStatus: string | null;
+  /** ISO timestamp set when auto-resume fires for this task, to prevent double-launch */
+  resumedAt: string | null;
 }
 
 interface PersistedState {

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -27,6 +27,8 @@ export interface TaskInfo {
   agentCommand: string | null;
   paneId: string | null;
   lastAgentStatus: string | null;
+  /** ISO timestamp set when auto-resume fires for this task, to prevent double-launch */
+  resumedAt: string | null;
 }
 
 export interface LinearTeam {

--- a/src/hooks/useTerminalLifecycle.ts
+++ b/src/hooks/useTerminalLifecycle.ts
@@ -239,6 +239,35 @@ export function useTerminalLifecycle(
               const unsubCwd = window.electronAPI.pty.onCwd(paneId, send);
               const fallback = setTimeout(send, 3000);
             }
+          } else if (!result.snapshot) {
+            // No pending command and no warm-restore snapshot → cold or fresh session.
+            // Check for an active task that was interrupted (e.g. version upgrade,
+            // app crash) and auto-relaunch its agent command.
+            void (async () => {
+              const activeTasks = await window.electronAPI.tasks.getAll({ status: "active" });
+              const resumeTask = activeTasks.find(
+                (t) => t.paneId === paneId && !t.resumedAt && t.agentCommand,
+              );
+              if (!resumeTask || disposed) return;
+
+              // Mark resumed immediately to prevent double-launch on re-mount
+              void window.electronAPI.tasks.update(resumeTask.id, {
+                resumedAt: new Date().toISOString(),
+              });
+
+              // Wait for shell prompt (CWD event), then relaunch
+              let sent = false;
+              let unsubCwd: (() => void) | null = null;
+              const send = () => {
+                if (sent || disposed) return;
+                sent = true;
+                if (resumeFallback) clearTimeout(resumeFallback);
+                unsubCwd?.();
+                write(resumeTask.agentCommand! + "\n");
+              };
+              unsubCwd = window.electronAPI.pty.onCwd(paneId, send);
+              const resumeFallback = setTimeout(send, 3000);
+            })();
           }
         }
       },


### PR DESCRIPTION
Closes orrybaram/manor#116

## Summary
- After a cold or fresh session restore, `useTerminalLifecycle` checks `tasks.json` for an active task whose `paneId` matches the restored pane
- If found (and not already resumed), writes the saved `agentCommand` to the PTY after the shell prompt is ready — same CWD-event pattern used for pending startup commands
- Adds `resumedAt: string | null` to `TaskInfo` to prevent double-launch if the pane is unmounted/remounted
- Warm restores (Claude still running, `snapshot` is non-null) are excluded — no interference with live sessions
- Prewarmed sessions for new tasks are unaffected (`pendingCmd` takes priority)

## ADR
`docs/decisions/adr-118-claude-auto-resume/`

## Test plan
- [ ] Quit Manor mid-task (Claude active), relaunch → Claude restarts in the correct pane
- [ ] Same-version restart (warm restore): Claude is not double-launched
- [ ] Task with `status: "completed"` is not resumed
- [ ] `resumedAt` is set after auto-resume fires, preventing re-launch on pane remount
- [ ] Tasks with `agentCommand: null` are skipped (user must relaunch manually)