### PR TITLE
fix: strip NODE_ENV and ELECTRON_* from PTY shell env

### DIFF
--- a/electron/terminal-host/session.test.ts
+++ b/electron/terminal-host/session.test.ts
@@ -20,7 +20,7 @@ vi.mock("../shell", () => ({
   },
 }));
 
-import { Session } from "./session";
+import { Session, buildShellEnv } from "./session";
 import type { StreamEvent } from "./types";
 
 function pushDataFrame(session: Session, data: string): void {
@@ -276,5 +276,79 @@ describe("Session", () => {
       expect(session.info.cols).toBe(120);
       expect(session.info.rows).toBe(40);
     });
+  });
+});
+
+describe("buildShellEnv", () => {
+  it("strips NODE_ENV from base env", () => {
+    const result = buildShellEnv({ NODE_ENV: "development", PATH: "/usr/bin" }, {});
+    expect(result).not.toHaveProperty("NODE_ENV");
+    expect(result.PATH).toBe("/usr/bin");
+  });
+
+  it("strips all ELECTRON_* keys", () => {
+    const result = buildShellEnv(
+      {
+        ELECTRON_RUN_AS_NODE: "1",
+        ELECTRON_NO_ASAR: "1",
+        ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
+        HOME: "/Users/test",
+      },
+      {},
+    );
+    expect(result).not.toHaveProperty("ELECTRON_RUN_AS_NODE");
+    expect(result).not.toHaveProperty("ELECTRON_NO_ASAR");
+    expect(result).not.toHaveProperty("ELECTRON_DISABLE_SECURITY_WARNINGS");
+    expect(result.HOME).toBe("/Users/test");
+  });
+
+  it("passes through unrelated vars unchanged", () => {
+    const result = buildShellEnv(
+      { HOME: "/Users/test", PATH: "/usr/bin:/usr/local/bin", LANG: "en_US.UTF-8" },
+      {},
+    );
+    expect(result.HOME).toBe("/Users/test");
+    expect(result.PATH).toBe("/usr/bin:/usr/local/bin");
+    expect(result.LANG).toBe("en_US.UTF-8");
+  });
+
+  it("merges overrides last, overrides take precedence over base", () => {
+    const result = buildShellEnv(
+      { TERM: "dumb", PATH: "/usr/bin" },
+      { TERM: "xterm-256color", MANOR_PANE_ID: "pane-42" },
+    );
+    expect(result.TERM).toBe("xterm-256color");
+    expect(result.MANOR_PANE_ID).toBe("pane-42");
+    expect(result.PATH).toBe("/usr/bin");
+  });
+
+  it("preserves MANOR_* vars from overrides", () => {
+    const result = buildShellEnv(
+      { HOME: "/Users/test" },
+      {
+        MANOR_PANE_ID: "session-abc",
+        MANOR_HISTFILE: "/tmp/hist",
+        TERM: "xterm-256color",
+        ZDOTDIR: "/tmp/zdot",
+        REAL_ZDOTDIR: "/Users/test",
+      },
+    );
+    expect(result.MANOR_PANE_ID).toBe("session-abc");
+    expect(result.MANOR_HISTFILE).toBe("/tmp/hist");
+    expect(result.ZDOTDIR).toBe("/tmp/zdot");
+    expect(result.REAL_ZDOTDIR).toBe("/Users/test");
+  });
+
+  it("skips undefined values in base env", () => {
+    const base: NodeJS.ProcessEnv = { HOME: "/Users/test", UNDEFINED_VAR: undefined };
+    const result = buildShellEnv(base, {});
+    expect(result).not.toHaveProperty("UNDEFINED_VAR");
+    expect(result.HOME).toBe("/Users/test");
+  });
+
+  it("clean base produces no NODE_ENV even if overrides omit it", () => {
+    const result = buildShellEnv({}, { TERM: "xterm-256color" });
+    expect(result).not.toHaveProperty("NODE_ENV");
+    expect(result.TERM).toBe("xterm-256color");
   });
 });

--- a/electron/terminal-host/session.ts
+++ b/electron/terminal-host/session.ts
@@ -37,6 +37,34 @@ import type {
 } from "./types";
 import { DEFAULT_TERMINAL_MODES } from "./types";
 
+/**
+ * Build the environment for a user-facing PTY shell.
+ *
+ * Strips vars that must not leak from the Manor Electron process into user shells:
+ *   - NODE_ENV  — set to 'development' by Vite; tools like Jest and Next.js need
+ *                 to set it themselves from a clean slate.
+ *   - ELECTRON_* — Electron-runtime vars with no meaning in a user shell.
+ *
+ * The pty-subprocess.js fork() is intentionally excluded from this filtering; it
+ * is a Node.js subprocess that legitimately needs the full process environment.
+ *
+ * @param base      Source environment (pass process.env in production)
+ * @param overrides Manor-specific vars merged in last (MANOR_PANE_ID, TERM, etc.)
+ */
+export function buildShellEnv(
+  base: NodeJS.ProcessEnv,
+  overrides: Record<string, string>,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(base)) {
+    if (value === undefined) continue;
+    if (key === "NODE_ENV") continue;
+    if (key.startsWith("ELECTRON_")) continue;
+    env[key] = value;
+  }
+  return { ...env, ...overrides };
+}
+
 export class Session {
   readonly sessionId: string;
   prewarmed = false;
@@ -192,14 +220,13 @@ export class Session {
           cwd: this.cwd || process.env.HOME || "/",
           cols: this.cols,
           rows: this.rows,
-          env: {
-            ...(process.env as Record<string, string>),
+          env: buildShellEnv(process.env, {
             MANOR_PANE_ID: this.sessionId,
             TERM: "xterm-256color",
             ZDOTDIR: zdotdir,
             REAL_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME || "",
             MANOR_HISTFILE: histfile,
-          },
+          }),
         };
 
         this.writeToSubprocess(encodeJsonFrame(MSG.SPAWN, spawnPayload));


### PR DESCRIPTION
## Summary

Closes #117 — Terminal panes spawned from Manor dev mode inherit `NODE_ENV=development` (and `ELECTRON_*` vars) from the Electron process, breaking Jest, `next build`, and any tool that checks `NODE_ENV` before setting it itself.

- Extracts a pure `buildShellEnv(base, overrides)` helper in `electron/terminal-host/session.ts` that strips `NODE_ENV` and any `ELECTRON_*` key before passing env to `node-pty`
- The `fork()` for `pty-subprocess.js` is intentionally left untouched — it's a Node.js subprocess that legitimately needs the full process env
- Adds 7 unit tests for `buildShellEnv` covering: NODE_ENV stripped, ELECTRON_* stripped, unrelated vars preserved, overrides take precedence, MANOR_* vars preserved, undefined values skipped

## Test plan

- [ ] `pnpm test electron/terminal-host/session.test.ts` — 33 tests pass (26 existing + 7 new)
- [ ] Open a Manor terminal pane and run `echo $NODE_ENV` — should be empty
- [ ] Run `npm test` in a Next.js project from a Manor terminal — no NODE_ENV=development pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)