### PR TITLE
fix: handle PTY create rejection so New Terminal doesn't spin forever

### DIFF
--- a/src/hooks/useTerminalLifecycle.ts
+++ b/src/hooks/useTerminalLifecycle.ts
@@ -242,6 +242,13 @@ export function useTerminalLifecycle(
           }
         }
       },
+      (err: unknown) => {
+        if (!disposed) {
+          setPtyError(
+            err instanceof Error ? err.message : "Failed to create terminal session",
+          );
+        }
+      },
     );
 
     // Terminal title changes (OSC sequences) → store


### PR DESCRIPTION
## Summary

- Adds a rejection handler to the `create()` promise in `useTerminalLifecycle` so that IPC-level rejections (e.g. `validatePtyArgs` throwing before the try/catch) surface as a visible error via `setPtyError` instead of leaving the terminal tab in an infinite loading state.

## Root cause

`pty:create` calls `validatePtyArgs` **outside** its try/catch. If it throws (e.g. on zero cols/rows when the container isn't sized yet), the IPC promise rejects — not resolves with `{ ok: false }`. The `.then(successHandler)` had no second argument, so the rejection was swallowed and the UI stayed stuck.

## Test plan

- [ ] Open a project with no tabs open (empty workspace state)
- [ ] Click **New Terminal** — terminal should open and load a shell
- [ ] Verify CMD+T also continues to work
- [ ] Verify that a genuine PTY error shows an error message rather than a spinner

Closes #124