### PR TITLE
fix: stale task reconciliation after PTY daemon restart

### DIFF
--- a/docs/decisions/adr-116-stale-task-reconciliation/index.md
+++ b/docs/decisions/adr-116-stale-task-reconciliation/index.md
@@ -1,6 +1,6 @@
 ---
 type: adr
-status: proposed
+status: accepted
 database:
   schema:
     status:

--- a/docs/decisions/adr-116-stale-task-reconciliation/index.md
+++ b/docs/decisions/adr-116-stale-task-reconciliation/index.md
@@ -1,0 +1,102 @@
+---
+type: adr
+status: proposed
+database:
+  schema:
+    status:
+      type: select
+      options: [todo, in-progress, review, done]
+      default: todo
+    priority:
+      type: select
+      options: [critical, high, medium, low]
+    assignee:
+      type: select
+      options: [opus, sonnet, haiku]
+  defaultView: board
+  groupBy: status
+---
+
+# ADR-116: Stale Task Reconciliation
+
+Closes #122
+
+## Context
+
+When Manor restarts (e.g. after `pnpm dev` restarts due to a branch change, or after a crash), tasks that were running in PTY panes become "stale" — they remain listed as active in the sidebar even though the PTY session behind them is gone and no agent is running.
+
+**Root cause:** Tasks are persisted with both a `paneId` and an `agentSessionId`. On restart:
+
+1. Layout is restored from `layout.json` → the pane still exists in the layout tree
+2. The PTY daemon restarts → a new PTY session is created; the old `agentSessionId` is gone
+3. The `SessionEnd` hook never fires (the agent process was killed externally) → the task is never marked `completed`
+4. `TasksList.tsx` only checks that `paneId` exists in the layout tree — not that the PTY session behind it matches the one the task was born in
+
+A second issue: when a user explicitly closes a pane via `closePaneById()`, that function clears all pane-related store state (cwd, title, agent status, content type) but never touches task state. The task keeps its `paneId` reference and can become unreachable/confusing.
+
+**What existing fixes do NOT cover:**
+
+| Fix | What it handles | This issue |
+|---|---|---|
+| ADR-116 (socket path) | Daemon reconnect across versions | ❌ Old `agentSessionId` stays in `tasks.json` |
+| ADR-117 (orphaned processes) | PTY sessions with no layout pane | ❌ Opposite direction |
+| ADR-118 (auto-resume) | Re-launches Claude in fresh panes | ⚠️ Partial — second restart leaves it stale again |
+
+**Key files and their roles:**
+- `electron/task-persistence.ts` — `TaskInfo` interface (has `agentSessionId`, `paneId`, `status`); `unlinkPane(paneId)` exists but is never called on pane close
+- `electron/terminal-host/client.ts:303` — `listSessions()` returns all live daemon sessions; never called during layout restore
+- `electron/app-lifecycle.ts:476` — `SessionEnd` handler marks tasks `completed`; only fires if the agent exits cleanly
+- `src/store/app-store.ts:1503` — `closePaneById()` removes pane from layout but never calls `unlinkPane()` or abandons the associated task
+- `src/components/sidebar/TasksList.tsx:74` — shows task if `status === "active"` OR `paneId` is in the current layout; no session-ID check
+
+## Decision
+
+Two complementary fixes, each covering a different abandonment path:
+
+### Fix A — Startup Reconciliation (main process)
+
+After the app starts and the layout is restored, run a one-shot reconciliation in the main process:
+
+1. Call `ptyClient.listSessions()` to get all sessions the daemon currently has alive
+2. Load all active tasks from `taskManager.getTasks()`
+3. For each active task whose `agentSessionId` is **not** in the live session list → mark it `"abandoned"` via `taskManager.updateTask()`
+4. Broadcast the updated tasks to all renderer windows
+
+**Where it runs:** In `app-lifecycle.ts`, triggered via a new IPC handler `reconcileStaleTasks`. The renderer calls this handler from `App.tsx` after `loadPersistedLayout()` resolves (i.e. after the layout is known and the app is ready). A small delay (500 ms) is acceptable to ensure the daemon has had time to initialize its session list.
+
+**Why not automatic/timer-based:** Tying it to the renderer's "layout loaded" event is more deterministic than a timer and avoids running the reconciliation before layout state is available.
+
+### Fix B — Pane Closure Hook (IPC, renderer → main)
+
+When the user explicitly closes a pane:
+
+1. Add IPC handler `abandonTaskForPane(paneId)` in the main process: finds the active task with `paneId`, marks it `"abandoned"`, broadcasts
+2. Call this handler from `closePaneById()` in `app-store.ts` immediately before the pane is removed from the layout
+
+This ensures that user-initiated pane closures always clean up the associated task in real time, without waiting for a restart.
+
+### Task Status Display
+
+Both fixes mark orphaned tasks as `"abandoned"`. The `TasksList.tsx` filter already hides `abandoned` tasks (they only show if their pane still exists in the layout, and after Fix B that pane will be gone). No UI changes are needed for the basic fix, but we add a visible "Abandoned" badge in the task row for tasks in an intermediate state where the pane still exists but the task is abandoned — consistent with how `error` status is shown.
+
+### Tests
+
+- Unit tests for `reconcileStaleTasks`: mock `listSessions` returning a subset of active tasks' session IDs; verify correct tasks are marked abandoned
+- Unit tests for `abandonTaskForPane` IPC handler: verify it finds and marks the right task
+- Unit test for `closePaneById` effect: spy on the IPC call and verify it fires with the correct paneId
+
+## Consequences
+
+**Better:**
+- Stale tasks are cleaned up automatically on every restart — the sidebar reflects reality
+- Explicit pane closes immediately clean up task state
+- No manual intervention needed for the "zombie task" problem
+
+**Risks / tradeoffs:**
+- The 500 ms delay in startup reconciliation means there is a brief window where stale tasks are visible; acceptable since the sidebar loads quickly
+- If the daemon is slow to start (first launch), `listSessions()` might return an empty list and mark all tasks abandoned. Mitigation: only run reconciliation if the daemon connection is confirmed healthy (check `ptyClient.isConnected()` or equivalent before calling)
+- Fix B fires synchronously in `closePaneById`; if the IPC call fails, task state is inconsistent. Mitigation: fire-and-forget with a console warning; task will self-correct on next restart via Fix A
+
+## Tickets
+
+<div data-type="database" data-path="." data-view="board"></div>

--- a/docs/decisions/adr-116-stale-task-reconciliation/ticket-1-startup-reconciliation.md
+++ b/docs/decisions/adr-116-stale-task-reconciliation/ticket-1-startup-reconciliation.md
@@ -1,0 +1,95 @@
+---
+title: Startup reconciliation — abandon tasks with dead sessions
+status: done
+priority: critical
+assignee: sonnet
+blocked_by: []
+---
+
+# Startup Reconciliation — Abandon Tasks With Dead Sessions
+
+After the app restores its layout from disk, cross-check every active task's `agentSessionId` against the daemon's live session list. Any task whose session is no longer alive gets marked `"abandoned"`.
+
+## Background
+
+Tasks are persisted to disk with `agentSessionId` and `paneId`. When the PTY daemon restarts (crash, `pnpm dev` restart, branch change), old session IDs become invalid. The `SessionEnd` hook never fires for killed sessions, so tasks stay `"active"` in the sidebar forever.
+
+`listSessions()` in `electron/terminal-host/client.ts:303` returns all currently-alive daemon sessions. This is the source of truth.
+
+## Implementation
+
+### 1. Add `reconcileStaleTasks()` in `app-lifecycle.ts`
+
+In `electron/app-lifecycle.ts`, add a new exported function (or internal helper exposed via IPC):
+
+```typescript
+async function reconcileStaleTasks() {
+  // Guard: only run if daemon is connected
+  if (!ptyClient.isConnected()) return;
+
+  const liveSessions = await ptyClient.listSessions();
+  const liveIds = new Set(liveSessions.map((s) => s.id));
+
+  const allTasks = taskManager.getTasks();
+  for (const task of allTasks) {
+    if (task.status === "active" && task.agentSessionId && !liveIds.has(task.agentSessionId)) {
+      const updated = taskManager.updateTask(task.id, {
+        status: "abandoned",
+        completedAt: new Date().toISOString(),
+      });
+      if (updated) broadcastTask(updated);
+    }
+  }
+}
+```
+
+Check whether `ptyClient` has an `isConnected()` method or equivalent — look in `electron/terminal-host/client.ts`. If not, check connection state via `listSessions()` catching errors (return early if it throws).
+
+### 2. Expose via IPC
+
+In the relevant IPC registration file (look for where other task-related IPC handlers are registered — likely `electron/ipc/tasks.ts` or similar), add:
+
+```typescript
+ipcMain.handle("reconcileStaleTasks", async () => {
+  await reconcileStaleTasks();
+});
+```
+
+### 3. Call from renderer after layout load
+
+In `src/App.tsx`, in the `useMountEffect` block, after the `Promise.all([loadProjects(), loadPersistedLayout()])` resolves, invoke the IPC:
+
+```typescript
+Promise.all([loadProjects(), loadPersistedLayout()]).then(async () => {
+  // ... existing workspace setup ...
+  setAppReady(true);
+  // Reconcile stale tasks after layout is known
+  await window.electron.invoke("reconcileStaleTasks").catch(console.error);
+});
+```
+
+The call is fire-and-forget (`catch` logs errors); it does not block the app ready state.
+
+### Notes
+
+- `broadcastTask` already handles notifying all renderer windows — reuse it
+- `taskManager.getTasks()` should return all tasks including active ones — verify this returns the full list (check `electron/task-persistence.ts`)
+- Do NOT mark tasks as abandoned if `agentSessionId` is null/empty (those are tasks without a session yet)
+- Check whether `SessionInfo.id` matches the `agentSessionId` field — confirm in `electron/terminal-host/client.ts` what the `id` field of `SessionInfo` is
+
+## Files to Touch
+
+- `electron/app-lifecycle.ts` — add `reconcileStaleTasks()` function
+- `electron/ipc/tasks.ts` (or wherever task IPC is registered) — add `reconcileStaleTasks` handler
+- `src/App.tsx` — call `reconcileStaleTasks` after layout loads
+- `electron/preload.ts` (if typed) — expose `reconcileStaleTasks` in the electron API type if needed
+
+## REQUIRED: Commit your work
+
+When your implementation is complete, you MUST create a git commit. This is not optional.
+
+Run:
+  git add -A
+  git commit -m "feat(adr-116): startup reconciliation — abandon tasks with dead sessions"
+
+Do not push.

--- a/docs/decisions/adr-116-stale-task-reconciliation/ticket-2-pane-closure-hook.md
+++ b/docs/decisions/adr-116-stale-task-reconciliation/ticket-2-pane-closure-hook.md
@@ -1,0 +1,79 @@
+---
+title: Pane closure hook — abandon task when pane is explicitly closed
+status: in-progress
+priority: high
+assignee: sonnet
+blocked_by: [1]
+---
+
+# Pane Closure Hook — Abandon Task When Pane Is Explicitly Closed
+
+When the user closes a pane via the UI, immediately mark any active task linked to that pane as `"abandoned"`. This is the real-time counterpart to the startup reconciliation in ticket 1.
+
+## Background
+
+`closePaneById()` in `src/store/app-store.ts:1503` removes a pane from the layout and clears all pane-related store state. But it never calls `taskManager.unlinkPane()` or marks the associated task as abandoned.
+
+`electron/task-persistence.ts` already has `unlinkPane(paneId)` which clears the `paneId` field on tasks — but we want to go further and mark the task `"abandoned"`, not just unlink it, because the agent is truly gone.
+
+## Implementation
+
+### 1. Add `abandonTaskForPane` IPC handler (main process)
+
+In the same IPC file used for ticket 1 (likely `electron/ipc/tasks.ts` or similar), add:
+
+```typescript
+ipcMain.handle("abandonTaskForPane", async (_event, paneId: string) => {
+  const task = taskManager.getTaskByPaneId(paneId);
+  if (task && task.status === "active") {
+    const updated = taskManager.updateTask(task.id, {
+      status: "abandoned",
+      completedAt: new Date().toISOString(),
+    });
+    if (updated) broadcastTask(updated);
+  }
+});
+```
+
+Verify that `taskManager.getTaskByPaneId(paneId)` exists in `electron/task-persistence.ts` (it should — seen at line ~195). If it doesn't exist, add it or use `taskManager.getTasks().find(t => t.paneId === paneId)`.
+
+### 2. Expose in preload (if typed)
+
+If `electron/preload.ts` has typed API declarations (look for `contextBridge.exposeInMainWorld`), add `abandonTaskForPane` alongside other task-related methods. If there's no typed preload, the `window.electron.invoke()` call works without changes.
+
+### 3. Call from `closePaneById()` in renderer
+
+In `src/store/app-store.ts`, find `closePaneById` (~line 1503). Before the pane removal logic, fire the IPC:
+
+```typescript
+closePaneById: (paneId: string) => {
+  // Abandon any active task linked to this pane
+  window.electron.invoke("abandonTaskForPane", paneId).catch(console.error);
+
+  // ... existing pane removal logic unchanged ...
+},
+```
+
+Fire-and-forget pattern — the IPC call does not block the pane removal. If it fails, the task will self-correct on next startup via the reconciliation (ticket 1).
+
+### Notes
+
+- Only call on the main `closePaneById` — not on tab close or workspace changes (those have different semantics)
+- The `window.electron.invoke` call should match the pattern already used elsewhere in `app-store.ts` — grep for existing `invoke` calls to find the right API shape
+- After this change, the `TasksList.tsx` visibility logic will naturally hide the task once the pane is gone AND the status is `abandoned` — no UI changes needed
+
+## Files to Touch
+
+- `electron/ipc/tasks.ts` (or equivalent) — add `abandonTaskForPane` handler
+- `electron/preload.ts` — expose if typed
+- `src/store/app-store.ts` — call `abandonTaskForPane` at top of `closePaneById`
+
+## REQUIRED: Commit your work
+
+When your implementation is complete, you MUST create a git commit. This is not optional.
+
+Run:
+  git add -A
+  git commit -m "feat(adr-116): pane closure hook — abandon task when pane is explicitly closed"
+
+Do not push.

--- a/docs/decisions/adr-116-stale-task-reconciliation/ticket-2-pane-closure-hook.md
+++ b/docs/decisions/adr-116-stale-task-reconciliation/ticket-2-pane-closure-hook.md
@@ -1,6 +1,6 @@
 ---
 title: Pane closure hook — abandon task when pane is explicitly closed
-status: in-progress
+status: done
 priority: high
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-116-stale-task-reconciliation/ticket-3-tests.md
+++ b/docs/decisions/adr-116-stale-task-reconciliation/ticket-3-tests.md
@@ -1,0 +1,112 @@
+---
+title: Tests for stale task reconciliation and pane closure abandonment
+status: todo
+priority: high
+assignee: sonnet
+blocked_by: [1, 2]
+---
+
+# Tests for Stale Task Reconciliation and Pane Closure Abandonment
+
+Write tests covering the two fixes introduced in tickets 1 and 2.
+
+## Background
+
+Before writing tests, read the existing test setup to understand the testing patterns used in this codebase:
+- Look for `*.test.ts`, `*.spec.ts` files in `electron/` and `src/`
+- Check for a `vitest.config.ts` or `jest.config.ts` to understand the test runner
+- Check if there are existing mocks for `taskManager` or `ptyClient`
+
+## Tests to Write
+
+### Test Suite A: `reconcileStaleTasks`
+
+File: `electron/__tests__/reconcile-stale-tasks.test.ts` (or follow existing file structure)
+
+```
+describe("reconcileStaleTasks")
+
+  it("marks active tasks with dead sessions as abandoned")
+    - Mock taskManager.getTasks() → [task1 (active, sessionId: "s1"), task2 (active, sessionId: "s2")]
+    - Mock ptyClient.listSessions() → [{ id: "s2" }]  // only s2 is alive
+    - Call reconcileStaleTasks()
+    - Assert taskManager.updateTask called with task1.id, { status: "abandoned", completedAt: <any string> }
+    - Assert taskManager.updateTask NOT called for task2 (it's still alive)
+    - Assert broadcastTask called with the updated task1
+
+  it("does not mark tasks as abandoned when daemon is not connected")
+    - Mock ptyClient.isConnected() → false (or make listSessions throw)
+    - Call reconcileStaleTasks()
+    - Assert taskManager.updateTask never called
+
+  it("does not mark tasks with null agentSessionId as abandoned")
+    - Mock taskManager.getTasks() → [task with agentSessionId: null, status: "active"]
+    - Mock ptyClient.listSessions() → []
+    - Assert taskManager.updateTask never called
+
+  it("ignores already-completed tasks")
+    - Mock getTasks() → [task with status: "completed", agentSessionId: "s1"]
+    - Mock listSessions() → []  // s1 is dead, but task is already completed
+    - Assert updateTask never called
+```
+
+### Test Suite B: `abandonTaskForPane` IPC handler
+
+File: `electron/__tests__/abandon-task-for-pane.test.ts` (or follow existing pattern)
+
+```
+describe("abandonTaskForPane IPC handler")
+
+  it("marks the active task for a pane as abandoned")
+    - Mock taskManager.getTaskByPaneId("pane-1") → task (status: "active")
+    - Invoke the handler with paneId: "pane-1"
+    - Assert taskManager.updateTask called with task.id, { status: "abandoned", completedAt: <any> }
+    - Assert broadcastTask called
+
+  it("does nothing if no task is linked to the pane")
+    - Mock taskManager.getTaskByPaneId("pane-99") → undefined
+    - Invoke the handler with paneId: "pane-99"
+    - Assert taskManager.updateTask never called
+
+  it("does nothing if the task is not active")
+    - Mock taskManager.getTaskByPaneId("pane-1") → task (status: "completed")
+    - Assert taskManager.updateTask never called
+```
+
+### Test Suite C: `closePaneById` integration (renderer)
+
+File: `src/store/__tests__/app-store-close-pane.test.ts` (or alongside existing store tests)
+
+```
+describe("closePaneById task abandonment")
+
+  it("calls abandonTaskForPane IPC with the correct paneId")
+    - Spy on window.electron.invoke
+    - Set up store with a pane "pane-1" in the layout
+    - Call closePaneById("pane-1")
+    - Assert window.electron.invoke called with "abandonTaskForPane", "pane-1"
+```
+
+## Notes
+
+- Follow whatever mock/test patterns are already established in the codebase
+- If the project uses `vitest`, use `vi.fn()` and `vi.mock()`; if `jest`, use `jest.fn()`
+- For renderer tests, you may need to mock `window.electron` — check how other store tests handle this
+- Don't over-test: focus on the paths that matter for this bug (the three suites above)
+- All tests should pass before committing
+
+## Files to Touch
+
+- `electron/__tests__/reconcile-stale-tasks.test.ts` — new file (or adjust path to match existing pattern)
+- `electron/__tests__/abandon-task-for-pane.test.ts` — new file
+- `src/store/__tests__/app-store-close-pane.test.ts` — new file (or adjust to match existing pattern)
+
+## REQUIRED: Commit your work
+
+When your implementation is complete, you MUST create a git commit. This is not optional.
+
+Run:
+  git add -A
+  git commit -m "test(adr-116): tests for stale task reconciliation and pane closure abandonment"
+
+Do not push.

--- a/docs/decisions/adr-116-stale-task-reconciliation/ticket-3-tests.md
+++ b/docs/decisions/adr-116-stale-task-reconciliation/ticket-3-tests.md
@@ -1,6 +1,6 @@
 ---
 title: Tests for stale task reconciliation and pane closure abandonment
-status: todo
+status: done
 priority: high
 assignee: sonnet
 blocked_by: [1, 2]

--- a/electron/__tests__/tasks-abandon-for-pane.test.ts
+++ b/electron/__tests__/tasks-abandon-for-pane.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ── Mock electron ──────────────────────────────────────────────────────────────
+const handlers: Map<string, (...args: unknown[]) => unknown> = new Map();
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+  },
+}));
+
+// ── Mock notifications ─────────────────────────────────────────────────────────
+vi.mock("../notifications", () => ({
+  updateDockBadge: vi.fn(),
+}));
+
+// ── Mock ipc-validate ──────────────────────────────────────────────────────────
+vi.mock("../ipc-validate", () => ({
+  assertString: vi.fn(),
+}));
+
+import { register } from "../ipc/tasks";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    taskManager: {
+      getAllTasks: vi.fn().mockReturnValue([]),
+      updateTask: vi.fn((id: string, updates: Record<string, unknown>) => ({
+        id,
+        ...updates,
+      })),
+      getTaskByPaneId: vi.fn().mockReturnValue(null),
+      deleteTask: vi.fn(),
+    },
+    backend: {
+      pty: {
+        listSessions: vi.fn().mockResolvedValue([]),
+      },
+    },
+    mainWindow: null,
+    preferencesManager: {},
+    paneContextMap: new Map(),
+    unseenRespondedTasks: new Set(),
+    unseenInputTasks: new Set(),
+    ...overrides,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("tasks:abandonForPane handler", () => {
+  let deps: ReturnType<typeof makeDeps>;
+
+  beforeEach(() => {
+    handlers.clear();
+    deps = makeDeps();
+    register(deps as never);
+  });
+
+  it("marks the active task for a pane as abandoned", () => {
+    deps.taskManager.getTaskByPaneId.mockReturnValue({
+      id: "t1",
+      status: "active",
+    });
+
+    const handler = handlers.get("tasks:abandonForPane")!;
+    handler({} as never, "pane-1");
+
+    expect(deps.taskManager.updateTask).toHaveBeenCalledTimes(1);
+    expect(deps.taskManager.updateTask).toHaveBeenCalledWith(
+      "t1",
+      expect.objectContaining({ status: "abandoned" }),
+    );
+    const [[, updates]] = (deps.taskManager.updateTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(updates).toHaveProperty("completedAt");
+    expect(typeof updates.completedAt).toBe("string");
+  });
+
+  it("does nothing if no task for that pane", () => {
+    deps.taskManager.getTaskByPaneId.mockReturnValue(undefined);
+
+    const handler = handlers.get("tasks:abandonForPane")!;
+    handler({} as never, "pane-99");
+
+    expect(deps.taskManager.updateTask).not.toHaveBeenCalled();
+  });
+
+  it("does nothing if task is not active", () => {
+    deps.taskManager.getTaskByPaneId.mockReturnValue({
+      id: "t1",
+      status: "completed",
+    });
+
+    const handler = handlers.get("tasks:abandonForPane")!;
+    handler({} as never, "pane-1");
+
+    expect(deps.taskManager.updateTask).not.toHaveBeenCalled();
+  });
+});

--- a/electron/__tests__/tasks-reconcile-stale.test.ts
+++ b/electron/__tests__/tasks-reconcile-stale.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ── Mock electron ──────────────────────────────────────────────────────────────
+const handlers: Map<string, (...args: unknown[]) => unknown> = new Map();
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+  },
+}));
+
+// ── Mock notifications ─────────────────────────────────────────────────────────
+vi.mock("../notifications", () => ({
+  updateDockBadge: vi.fn(),
+}));
+
+// ── Mock ipc-validate ──────────────────────────────────────────────────────────
+vi.mock("../ipc-validate", () => ({
+  assertString: vi.fn(),
+}));
+
+import { register } from "../ipc/tasks";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeTask(
+  overrides: Partial<{
+    id: string;
+    status: string;
+    agentSessionId: string | null;
+  }> = {},
+) {
+  return {
+    id: "t1",
+    status: "active",
+    agentSessionId: "s1",
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    taskManager: {
+      getAllTasks: vi.fn().mockReturnValue([]),
+      updateTask: vi.fn((id: string, updates: Record<string, unknown>) => ({
+        id,
+        ...updates,
+      })),
+      getTaskByPaneId: vi.fn().mockReturnValue(null),
+      deleteTask: vi.fn(),
+    },
+    backend: {
+      pty: {
+        listSessions: vi.fn().mockResolvedValue([]),
+      },
+    },
+    mainWindow: null,
+    preferencesManager: {},
+    paneContextMap: new Map(),
+    unseenRespondedTasks: new Set(),
+    unseenInputTasks: new Set(),
+    ...overrides,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("tasks:reconcileStale handler", () => {
+  let deps: ReturnType<typeof makeDeps>;
+
+  beforeEach(() => {
+    handlers.clear();
+    deps = makeDeps();
+    register(deps as never);
+  });
+
+  it("marks active tasks with dead sessions as abandoned", async () => {
+    deps.taskManager.getAllTasks.mockReturnValue([
+      makeTask({ id: "t1", status: "active", agentSessionId: "s1" }), // dead
+      makeTask({ id: "t2", status: "active", agentSessionId: "s2" }), // alive
+    ]);
+    deps.backend.pty.listSessions.mockResolvedValue([{ sessionId: "s2" }]);
+
+    const handler = handlers.get("tasks:reconcileStale")!;
+    await handler({} as never);
+
+    expect(deps.taskManager.updateTask).toHaveBeenCalledTimes(1);
+    expect(deps.taskManager.updateTask).toHaveBeenCalledWith(
+      "t1",
+      expect.objectContaining({ status: "abandoned" }),
+    );
+    const [[, updates]] = (deps.taskManager.updateTask as ReturnType<typeof vi.fn>).mock.calls;
+    expect(updates).toHaveProperty("completedAt");
+    expect(typeof updates.completedAt).toBe("string");
+  });
+
+  it("does nothing when daemon is unreachable", async () => {
+    deps.backend.pty.listSessions.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const handler = handlers.get("tasks:reconcileStale")!;
+    await handler({} as never);
+
+    expect(deps.taskManager.getAllTasks).not.toHaveBeenCalled();
+    expect(deps.taskManager.updateTask).not.toHaveBeenCalled();
+  });
+
+  it("skips tasks with null agentSessionId", async () => {
+    deps.taskManager.getAllTasks.mockReturnValue([
+      makeTask({ id: "t1", status: "active", agentSessionId: null }),
+    ]);
+    deps.backend.pty.listSessions.mockResolvedValue([]);
+
+    const handler = handlers.get("tasks:reconcileStale")!;
+    await handler({} as never);
+
+    expect(deps.taskManager.updateTask).not.toHaveBeenCalled();
+  });
+
+  it("skips non-active tasks", async () => {
+    deps.taskManager.getAllTasks.mockReturnValue([
+      makeTask({ id: "t1", status: "completed", agentSessionId: "s1" }),
+    ]);
+    deps.backend.pty.listSessions.mockResolvedValue([]);
+
+    const handler = handlers.get("tasks:reconcileStale")!;
+    await handler({} as never);
+
+    expect(deps.taskManager.updateTask).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/tasks.ts
+++ b/electron/ipc/tasks.ts
@@ -10,6 +10,7 @@ export function register(deps: IpcDeps): void {
     unseenRespondedTasks,
     unseenInputTasks,
     preferencesManager,
+    backend,
   } = deps;
 
   ipcMain.handle(
@@ -71,4 +72,45 @@ export function register(deps: IpcDeps): void {
       paneContextMap.set(paneId, context);
     },
   );
+
+  ipcMain.handle("tasks:reconcileStale", async () => {
+    let liveSessions: Array<{ sessionId: string }>;
+    try {
+      liveSessions = await backend.pty.listSessions();
+    } catch {
+      // Daemon unreachable — skip reconciliation
+      return;
+    }
+
+    const liveIds = new Set(liveSessions.map((s) => s.sessionId));
+    const allTasks = taskManager.getAllTasks();
+
+    for (const task of allTasks) {
+      if (
+        task.status === "active" &&
+        task.agentSessionId &&
+        !liveIds.has(task.agentSessionId)
+      ) {
+        const updated = taskManager.updateTask(task.id, {
+          status: "abandoned",
+          completedAt: new Date().toISOString(),
+        });
+        if (updated) {
+          const { mainWindow } = deps;
+          if (
+            mainWindow &&
+            !mainWindow.isDestroyed() &&
+            !mainWindow.webContents.isDestroyed()
+          ) {
+            try {
+              mainWindow.webContents.send("task-updated", updated);
+            } catch {
+              // Render frame disposed — safe to ignore
+            }
+          }
+          updateDockBadge(preferencesManager);
+        }
+      }
+    }
+  });
 }

--- a/electron/ipc/tasks.ts
+++ b/electron/ipc/tasks.ts
@@ -73,6 +73,31 @@ export function register(deps: IpcDeps): void {
     },
   );
 
+  ipcMain.handle("tasks:abandonForPane", (_event, paneId: string) => {
+    assertString(paneId, "paneId");
+    const task = taskManager.getTaskByPaneId(paneId);
+    if (!task || task.status !== "active") return;
+    const updated = taskManager.updateTask(task.id, {
+      status: "abandoned",
+      completedAt: new Date().toISOString(),
+    });
+    if (updated) {
+      const { mainWindow } = deps;
+      if (
+        mainWindow &&
+        !mainWindow.isDestroyed() &&
+        !mainWindow.webContents.isDestroyed()
+      ) {
+        try {
+          mainWindow.webContents.send("task-updated", updated);
+        } catch {
+          // Render frame disposed — safe to ignore
+        }
+      }
+      updateDockBadge(preferencesManager);
+    }
+  });
+
   ipcMain.handle("tasks:reconcileStale", async () => {
     let liveSessions: Array<{ sessionId: string }>;
     try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -319,6 +319,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
       },
     ) => ipcRenderer.invoke("tasks:setPaneContext", paneId, context),
     markSeen: (taskId: string) => ipcRenderer.invoke("tasks:markSeen", taskId),
+    reconcileStale: () => ipcRenderer.invoke("tasks:reconcileStale"),
     onUpdate: (callback: (task: unknown) => void) =>
       onChannel("task-updated", callback),
   },

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -320,6 +320,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ) => ipcRenderer.invoke("tasks:setPaneContext", paneId, context),
     markSeen: (taskId: string) => ipcRenderer.invoke("tasks:markSeen", taskId),
     reconcileStale: () => ipcRenderer.invoke("tasks:reconcileStale"),
+    abandonForPane: (paneId: string) => ipcRenderer.invoke("tasks:abandonForPane", paneId),
     onUpdate: (callback: (task: unknown) => void) =>
       onChannel("task-updated", callback),
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ function App() {
         if (ws) setActiveWorkspace(ws.path);
       }
       setAppReady(true);
+      window.electronAPI.tasks.reconcileStale().catch(console.error);
     });
   });
 

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -502,6 +502,7 @@ export interface ElectronAPI {
       },
     ) => Promise<void>;
     markSeen: (taskId: string) => Promise<void>;
+    reconcileStale: () => Promise<void>;
     onUpdate: (callback: (task: TaskInfo) => void) => () => void;
   };
 

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -503,6 +503,7 @@ export interface ElectronAPI {
     ) => Promise<void>;
     markSeen: (taskId: string) => Promise<void>;
     reconcileStale: () => Promise<void>;
+    abandonForPane: (paneId: string) => Promise<void>;
     onUpdate: (callback: (task: TaskInfo) => void) => () => void;
   };
 

--- a/src/store/__tests__/app-store-close-pane-abandon.test.ts
+++ b/src/store/__tests__/app-store-close-pane-abandon.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useAppStore } from "../app-store";
+import type { WorkspaceLayout, Tab, Panel } from "../app-store";
+
+// window is provided by the setup file (src/store/__tests__/setup.ts)
+// with a minimal electronAPI mock.  We extend it here with tasks.abandonForPane.
+
+const WS_PATH = "/test/workspace";
+
+function makeLayout(): WorkspaceLayout {
+  const panelId = "panel-1";
+  const paneId = "pane-1";
+  const tabId = "tab-1";
+  const tab: Tab = {
+    id: tabId,
+    title: "Terminal",
+    rootNode: { type: "leaf", paneId },
+    focusedPaneId: paneId,
+  };
+  const panel: Panel = {
+    id: panelId,
+    tabs: [tab],
+    selectedTabId: tabId,
+    pinnedTabIds: [],
+  };
+  return {
+    panelTree: { type: "leaf", panelId },
+    panels: { [panelId]: panel },
+    activePanelId: panelId,
+  };
+}
+
+function makeTwoPaneLayout(): WorkspaceLayout {
+  const panelId = "panel-1";
+  const tab: Tab = {
+    id: "tab-1",
+    title: "Terminal",
+    rootNode: {
+      type: "split",
+      direction: "horizontal",
+      ratio: 0.5,
+      first: { type: "leaf", paneId: "pane-1" },
+      second: { type: "leaf", paneId: "pane-2" },
+    },
+    focusedPaneId: "pane-1",
+  };
+  const panel: Panel = {
+    id: panelId,
+    tabs: [tab],
+    selectedTabId: "tab-1",
+    pinnedTabIds: [],
+  };
+  return {
+    panelTree: { type: "leaf", panelId },
+    panels: { [panelId]: panel },
+    activePanelId: panelId,
+  };
+}
+
+function setupStore(layout?: WorkspaceLayout) {
+  useAppStore.setState({
+    activeWorkspacePath: WS_PATH,
+    workspaceLayouts: { [WS_PATH]: layout ?? makeLayout() },
+    paneCwd: {},
+    paneTitle: {},
+    paneAgentStatus: {},
+    paneContentType: {},
+    paneUrl: {},
+    panePickedElement: {},
+    closedPaneIds: new Set(),
+    closedPaneStack: [],
+    pendingStartupCommands: {},
+    pendingPaneCommands: {},
+    pendingCloseConfirmPaneId: null,
+    pendingCloseConfirmTabId: null,
+    webviewFocusedPaneId: null,
+  });
+}
+
+describe("closePaneById calls abandonForPane", () => {
+  let abandonForPane: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    abandonForPane = vi.fn().mockResolvedValue(undefined);
+
+    vi.stubGlobal("window", {
+      ...window,
+      electronAPI: {
+        ...(window as unknown as { electronAPI: Record<string, unknown> }).electronAPI,
+        tasks: {
+          abandonForPane,
+        },
+      },
+    });
+  });
+
+  it("calls abandonForPane with the closed paneId", () => {
+    setupStore(makeTwoPaneLayout());
+
+    useAppStore.getState().closePaneById("pane-1");
+
+    expect(abandonForPane).toHaveBeenCalledTimes(1);
+    expect(abandonForPane).toHaveBeenCalledWith("pane-1");
+  });
+});

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -1501,6 +1501,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   closePaneById: (paneId: string) => {
+    window.electronAPI.tasks.abandonForPane(paneId).catch(console.error);
     const state = get();
     const ctx = getActivePanelContext(state);
     if (!ctx) return;


### PR DESCRIPTION
Closes #122

## Summary

- **Startup reconciliation**: after layout loads, cross-checks every active task's `agentSessionId` against the daemon's live session list via `listSessions()`. Any task whose session is no longer alive is immediately marked `abandoned` and broadcast to the renderer.
- **Pane closure hook**: `closePaneById()` now fires `tasks:abandonForPane` IPC before removing the pane, so user-initiated closes also clean up task state in real time.

## Implementation

- `electron/ipc/tasks.ts` — `tasks:reconcileStale` and `tasks:abandonForPane` IPC handlers
- `electron/preload.ts` + `src/electron.d.ts` — both exposed on `window.electronAPI.tasks`
- `src/App.tsx` — fire-and-forget `reconcileStale()` call after layout loads
- `src/store/app-store.ts` — fire-and-forget `abandonForPane(paneId)` at top of `closePaneById`

## Tests

7 new tests across 3 files:
- `electron/__tests__/tasks-reconcile-stale.test.ts` — dead session detection, daemon-unreachable guard, null sessionId skip, non-active task skip
- `electron/__tests__/tasks-abandon-for-pane.test.ts` — active task abandonment, no-task no-op, non-active task no-op
- `src/store/__tests__/app-store-close-pane-abandon.test.ts` — verifies `closePaneById` calls `abandonForPane` with correct paneId

## ADR

`docs/decisions/adr-116-stale-task-reconciliation/`