### PR TITLE
fix(adr-144): preserve user-intended casing in git branch names

### DIFF
--- a/docs/decisions/adr-144-preserve-branch-name-casing/index.md
+++ b/docs/decisions/adr-144-preserve-branch-name-casing/index.md
@@ -1,6 +1,6 @@
 ---
 type: adr
-status: proposed
+status: accepted
 database:
   schema:
     status:

--- a/docs/decisions/adr-144-preserve-branch-name-casing/index.md
+++ b/docs/decisions/adr-144-preserve-branch-name-casing/index.md
@@ -1,0 +1,122 @@
+---
+type: adr
+status: proposed
+database:
+  schema:
+    status:
+      type: select
+      options: [todo, in-progress, review, done]
+      default: todo
+    priority:
+      type: select
+      options: [critical, high, medium, low]
+    assignee:
+      type: select
+      options: [opus, sonnet, haiku]
+  defaultView: board
+  groupBy: status
+---
+
+# ADR-144: Preserve user-intended casing in git branch names
+
+## Context
+
+When creating a workspace, Manor force-lowercases the git branch name. A user who
+entered a name containing uppercase (e.g. an issue key like `PROJ-123`) got a branch
+created as `proj-123`, while some references retained the original intent — leading to
+mismatch errors during workspace management, restore, and cleanup.
+
+Three problems combine to cause this:
+
+1. **Force-lowercasing.** Three duplicate `slugify()` implementations call
+   `.toLowerCase()` when deriving the branch name:
+   - `src/components/sidebar/NewWorkspaceDialog/NewWorkspaceDialog.tsx:16` — auto-fills
+     the branch preview from the Name field as you type (line 313) and on submit
+     (line 211).
+   - `src/components/command-palette/GitHubIssueDetailView.tsx:25` — builds
+     `${number}-${slugify(title)}` as the branch (line 55).
+   - `src/components/sidebar/ProjectSetupWizard/ProjectSetupWizard.tsx:15` — derives a
+     **project directory** name (filesystem only, not a branch).
+   - A fourth copy lives in `electron/persistence.ts:22`, used for the worktree
+     **directory** slug.
+
+2. **Directory/branch drift.** In `electron/persistence.ts:705-710`, the git branch is
+   `branch || name` while the worktree directory is `slugify(name)` (always lowercased).
+   If the branch retains case but the directory does not, the two drift apart. On
+   case-insensitive filesystems (macOS/APFS, Windows/NTFS) this surfaces as ref/path
+   collisions — `.git/refs/heads/MyFeature` vs a `myfeature` reference — producing
+   "branch already exists" / "cannot find ref" errors during restore and `git branch -D`
+   cleanup.
+
+3. **Case-sensitive comparisons.** Branch lookups use strict `===`:
+   - `src/components/command-palette/IssueDetailView.tsx:53` — `ws.branch === issue.branchName` (Linear API casing).
+   - `src/components/command-palette/GitHubIssueDetailView.tsx:61` — `ws.branch === branchName`.
+   - `src/hooks/usePrWatcher.ts:34` — `w.branch === branch` (GitHub API casing).
+   - `src/store/project-store.ts:442,546,688` — post-create / convert lookups.
+   When an external source disagrees on case, the lookup silently fails: a workspace
+   looks unlinked, or a duplicate gets created.
+
+**Why change?** Lowercasing is a URL-slug convention misapplied to git branches:
+- No existing ADR mandates it (checked `docs/decisions/`).
+- Git ref names are case-sensitive and fully support uppercase; only the
+  `git check-ref-format` character rules are mandatory.
+- GitHub branch names are case-sensitive (Linux servers).
+- Jira issue keys are uppercase by convention (`PROJ-123`); Jira DVCS / Smart-Commit and
+  GitHub–Jira branch linking key off that token, so lowercasing can break auto-linking —
+  the user's exact concern.
+
+User intent should win: preserve case, sanitize only what git actually forbids.
+
+## Decision
+
+**Preserve case in branch names; lowercase only filesystem directory slugs.**
+
+1. **New canonical util** `src/utils/branch-name.ts` exporting:
+   - `sanitizeBranchName(input)` — enforces `git check-ref-format` rules while
+     **preserving case**: trims, converts whitespace to `-`, strips forbidden ref
+     characters (`~ ^ : ? * [ \ @{ }` and control chars), collapses `..`, `//`, and
+     repeated `-`, trims leading/trailing separators, drops a trailing `.lock`, and keeps
+     `/` so namespaced branches (`feature/foo`, `user/PROJ-123`) still work.
+   - `toDirSlug(input)` — the existing lowercase filesystem slug behavior (for worktree
+     and project directory names, where lowercasing is harmless and desirable).
+   - `branchesEqual(a, b)` — case-insensitive branch comparison for **matching only**.
+
+2. **Renderer call sites** (`NewWorkspaceDialog`, `GitHubIssueDetailView`,
+   `IssueDetailView`, `ProjectSetupWizard`, `project-store`) switch to the util:
+   branch derivation → `sanitizeBranchName`; directory derivation → `toDirSlug`;
+   branch lookups → `branchesEqual`. The three duplicate `slugify()` definitions are
+   deleted.
+
+3. **Electron side** (`electron/persistence.ts`): branches preserve case via a
+   `sanitizeBranchName`; directory slugs stay lowercased via `toDirSlug`. Because
+   `electron/` and `src/` are separate TypeScript compilation units (`rootDir: electron`
+   vs `include: ["src"]`) they cannot import a shared module without a build restructure
+   (out of scope), so a small `electron/branch-name.ts` mirrors the two functions. Git
+   remains the source of truth for a workspace's real branch — `git worktree list` output
+   is never compared case-sensitively against a derived string.
+
+4. **Always pass exact git/GitHub casing to commands**; only *matching* is
+   case-insensitive.
+
+## Consequences
+
+**Better:**
+- Issue keys (`PROJ-123`) survive into the branch name, restoring Jira/GitHub
+  auto-linking.
+- Eliminates the ref/path casing-mismatch class on case-insensitive filesystems.
+- Branch lookups stop silently failing on external-API casing differences.
+- One canonical branch-name util in the renderer instead of three drifting copies.
+
+**Harder / risks:**
+- Two source-of-truth functions remain (renderer `src/utils/branch-name.ts` and
+  `electron/branch-name.ts`) because of the compile-unit boundary. Mitigated by keeping
+  them tiny and covered by tests; a future shared-dir restructure could merge them.
+- **Case-only directory collision** edge case persists: two names differing only by case
+  (`MyFeature` vs `myfeature`) both map to the same lowercase directory slug. This is
+  pre-existing, rare, and out of scope here — noted for follow-up if it bites.
+- Existing workspaces created under the old lowercased scheme are unaffected; the change
+  is forward-looking. `branchesEqual` makes old/new comparisons robust regardless.
+
+## Tickets
+
+<div data-type="database" data-path="." data-view="board"></div>

--- a/docs/decisions/adr-144-preserve-branch-name-casing/ticket-1-branch-name-util.md
+++ b/docs/decisions/adr-144-preserve-branch-name-casing/ticket-1-branch-name-util.md
@@ -1,0 +1,55 @@
+---
+title: Create canonical branch-name util with tests
+status: todo
+priority: critical
+assignee: sonnet
+blocked_by: []
+---
+
+# Create canonical branch-name util with tests
+
+Create a single renderer-side utility that owns branch-name and directory-slug logic,
+plus a case-insensitive comparison helper. No call sites change in this ticket — this is
+the foundation ticket-2 builds on.
+
+## Behavior
+
+`sanitizeBranchName(input: string): string` — enforce `git check-ref-format` rules while
+**preserving case**:
+- trim surrounding whitespace
+- convert internal whitespace runs to a single `-`
+- strip git-forbidden ref characters: `~ ^ : ? * [ \ ` and ASCII control chars, plus the
+  `@{` / `}` sequence characters and a bare `@`
+- collapse `..` → `.`, `//` → `/`, and repeated `-` → `-`
+- keep `/` so namespaced branches survive (`feature/foo`, `user/PROJ-123`)
+- trim leading/trailing `-`, `.`, `/`
+- drop a trailing `.lock` (case-insensitive)
+- do NOT lowercase — `PROJ-123-MyFeature` must come back as `PROJ-123-MyFeature`
+
+`toDirSlug(input: string): string` — the existing lowercase filesystem slug. Port the
+exact current behavior from `NewWorkspaceDialog.tsx` / `persistence.ts`:
+```
+str.toLowerCase()
+   .replace(/[^a-z0-9\s-]/g, "")
+   .replace(/[\s_]+/g, "-")
+   .replace(/-+/g, "-")
+   .replace(/^-|-$/g, "");
+```
+
+`branchesEqual(a?: string | null, b?: string | null): boolean` — case-insensitive
+equality used only for *matching* (never for passing to git). Return `false` if either is
+null/undefined; otherwise compare `a.toLowerCase() === b.toLowerCase()`.
+
+## Files to touch
+- `src/utils/branch-name.ts` — new file exporting `sanitizeBranchName`, `toDirSlug`,
+  `branchesEqual`.
+- `src/utils/__tests__/branch-name.test.ts` — new test file. Cover, at minimum:
+  - case preserved: `sanitizeBranchName("PROJ-123-MyFeature")` → `"PROJ-123-MyFeature"`
+  - spaces → hyphens: `"My Feature"` → `"My-Feature"`
+  - forbidden chars stripped: `"feat: do~thing?"` → no `: ~ ?` remain
+  - namespaced branch keeps slash: `"feature/Foo Bar"` → `"feature/Foo-Bar"`
+  - trailing `.lock` removed; leading/trailing separators trimmed; `..`/`//` collapsed
+  - `toDirSlug("PROJ-123 My Feature")` → `"proj-123-my-feature"` (still lowercase)
+  - `branchesEqual("MyBranch", "mybranch")` → `true`; `branchesEqual(null, "x")` → `false`
+
+Match the existing test framework/style in `src/utils/__tests__/`.

--- a/docs/decisions/adr-144-preserve-branch-name-casing/ticket-1-branch-name-util.md
+++ b/docs/decisions/adr-144-preserve-branch-name-casing/ticket-1-branch-name-util.md
@@ -1,6 +1,6 @@
 ---
 title: Create canonical branch-name util with tests
-status: todo
+status: done
 priority: critical
 assignee: sonnet
 blocked_by: []

--- a/docs/decisions/adr-144-preserve-branch-name-casing/ticket-2-wire-renderer-call-sites.md
+++ b/docs/decisions/adr-144-preserve-branch-name-casing/ticket-2-wire-renderer-call-sites.md
@@ -1,6 +1,6 @@
 ---
 title: Wire renderer call sites to the branch-name util
-status: todo
+status: done
 priority: high
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-144-preserve-branch-name-casing/ticket-2-wire-renderer-call-sites.md
+++ b/docs/decisions/adr-144-preserve-branch-name-casing/ticket-2-wire-renderer-call-sites.md
@@ -1,0 +1,49 @@
+---
+title: Wire renderer call sites to the branch-name util
+status: todo
+priority: high
+assignee: sonnet
+blocked_by: [1]
+---
+
+# Wire renderer call sites to the branch-name util
+
+Replace the three duplicate `slugify()` definitions and the case-sensitive branch
+comparisons in the renderer with the util from ticket-1. Import from
+`src/utils/branch-name.ts`.
+
+Rule of thumb: **branch derivation → `sanitizeBranchName` (preserves case); directory
+derivation → `toDirSlug` (lowercase); branch lookups → `branchesEqual`.**
+
+## Files to touch
+
+- `src/components/sidebar/NewWorkspaceDialog/NewWorkspaceDialog.tsx`
+  - Delete the local `slugify` (lines 16–23).
+  - The branch-preview auto-fill (line 313) and on-submit fallback (line 211) and the
+    open-handler default (line 144) derive a **branch** → use `sanitizeBranchName`.
+  - The placeholder/preview UX stays the same; just no forced lowercase. Typing
+    `PROJ-123 My Feature` in Name should preview `PROJ-123-My-Feature`.
+
+- `src/components/command-palette/GitHubIssueDetailView.tsx`
+  - Delete the local `slugify` (lines 25–31). Build the branch as
+    `${issueDetail.number}-${sanitizeBranchName(issueDetail.title)}` (line 55).
+  - The existing-workspace lookup (line 61) → `branchesEqual(ws.branch, branchName)`.
+
+- `src/components/command-palette/IssueDetailView.tsx`
+  - Existing-workspace lookup (line 53) → `branchesEqual(ws.branch, issue.branchName)`.
+
+- `src/components/sidebar/ProjectSetupWizard/ProjectSetupWizard.tsx`
+  - Delete the local `slugify` (lines 15–22). Its two uses (lines 89, 166) derive a
+    **project directory** name → use `toDirSlug` (behavior unchanged, just centralized).
+
+- `src/hooks/usePrWatcher.ts`
+  - Branch lookup (line 34) → `branchesEqual(w.branch, branch)`.
+
+- `src/store/project-store.ts`
+  - Post-create lookup (line 442): change the branch half to `branchesEqual(ws.branch, branchName)`
+    (keep the `ws.name === name` half as-is).
+  - Convert lookup (line 546): `branchesEqual(ws.branch, branch)`.
+  - Update-branch early-exit (line 688): `branchesEqual(ws.branch, branch)`.
+
+Verify no other local `slugify` definitions remain in `src/` after this
+(`grep -rn "function slugify" src`).

--- a/docs/decisions/adr-144-preserve-branch-name-casing/ticket-3-electron-persistence.md
+++ b/docs/decisions/adr-144-preserve-branch-name-casing/ticket-3-electron-persistence.md
@@ -1,0 +1,40 @@
+---
+title: Preserve branch casing in electron/persistence
+status: todo
+priority: high
+assignee: sonnet
+blocked_by: []
+---
+
+# Preserve branch casing in electron/persistence
+
+Apply the same policy on the main-process side: branches preserve case, directory slugs
+stay lowercase. `electron/` is a separate TS compilation unit (`rootDir: electron`) and
+cannot import `src/utils/branch-name.ts`, so mirror the two functions in a small electron
+module. This ticket touches only `electron/` files, so it does not overlap with ticket-2
+and may run in parallel.
+
+## Files to touch
+
+- `electron/branch-name.ts` — new file. Export `sanitizeBranchName` and `toDirSlug` with
+  **identical behavior** to `src/utils/branch-name.ts` (see ticket-1 spec). Keep it small;
+  add a one-line comment noting it intentionally mirrors the renderer util because the two
+  compile units can't share a module.
+
+- `electron/persistence.ts`
+  - Delete the local `slugify` (lines 22–29). Import `sanitizeBranchName` and `toDirSlug`
+    from `./branch-name`.
+  - `createWorktree` (around lines 705–710):
+    - branch: `const branchName = sanitizeBranchName(branch || name);` (was `branch || name`)
+    - directory slug: `const slug = toDirSlug(name);` (was `slugify(name)`)
+    - project base dir fallback (line 709): `toDirSlug(project.name)`
+  - `convertMainToWorktree` (around lines 849–852): directory slug → `toDirSlug(name)`;
+    project base dir fallback → `toDirSlug(project.name)`.
+  - Do NOT change how `removeWorktree` detects the branch — it reads `git worktree list`,
+    which is the source of truth and must stay exact-case. Leave the `git branch -D
+    ${branchName}` path using that detected value.
+
+## Notes
+- Git remains the source of truth for a workspace's real branch; never compare a derived
+  slug case-sensitively against `git worktree list` output.
+- Existing lowercased workspaces are unaffected — this is forward-looking only.

--- a/docs/decisions/adr-144-preserve-branch-name-casing/ticket-3-electron-persistence.md
+++ b/docs/decisions/adr-144-preserve-branch-name-casing/ticket-3-electron-persistence.md
@@ -1,6 +1,6 @@
 ---
 title: Preserve branch casing in electron/persistence
-status: todo
+status: done
 priority: high
 assignee: sonnet
 blocked_by: []

--- a/electron/branch-name.ts
+++ b/electron/branch-name.ts
@@ -1,0 +1,43 @@
+// Intentionally mirrors `src/utils/branch-name.ts`. The renderer and main
+// process are separate TS compile units (`rootDir: electron`), so they cannot
+// share a module — keep these two functions identical to that file.
+
+/**
+ * Enforce `git check-ref-format` rules while preserving case.
+ */
+export function sanitizeBranchName(input: string): string {
+  let result = input.trim();
+
+  // Internal whitespace runs -> single hyphen.
+  result = result.replace(/\s+/g, "-");
+
+  // Strip git-forbidden characters: ~ ^ : ? * [ \, the `{` `}` `@` sequence
+  // characters, and ASCII control chars.
+  // eslint-disable-next-line no-control-regex
+  result = result.replace(/[~^:?*[\\{}@\x00-\x1f\x7f]/g, "");
+
+  // Collapse repeated separators.
+  result = result.replace(/\.{2,}/g, ".");
+  result = result.replace(/\/{2,}/g, "/");
+  result = result.replace(/-{2,}/g, "-");
+
+  // Drop a trailing `.lock` (case-insensitive).
+  result = result.replace(/\.lock$/i, "");
+
+  // Trim leading/trailing separators.
+  result = result.replace(/^[-./]+|[-./]+$/g, "");
+
+  return result;
+}
+
+/**
+ * Lowercase filesystem slug.
+ */
+export function toDirSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/electron/persistence.ts
+++ b/electron/persistence.ts
@@ -9,6 +9,7 @@ import { BrowserWindow } from "electron";
 import type { LinearAssociation, LinkedIssue } from "./linear";
 import type { GitBackend } from "./backend/types";
 import { manorDataDir, worktreesDir } from "./paths";
+import { sanitizeBranchName, toDirSlug } from "./branch-name";
 
 const execAsync = promisify(exec);
 
@@ -17,15 +18,6 @@ function expandHome(p: string): string {
     return path.join(os.homedir(), p.slice(1));
   }
   return p;
-}
-
-function slugify(str: string): string {
-  return str
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/[\s_]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
 }
 
 export interface CustomCommand {
@@ -702,11 +694,11 @@ export class ProjectManager {
     const project = this.findProject(projectId);
     if (!project) return null;
 
-    const branchName = branch || name;
-    const slug = slugify(name);
+    const branchName = sanitizeBranchName(branch || name);
+    const slug = toDirSlug(name);
     const baseDir = project.worktreePath
       ? expandHome(project.worktreePath)
-      : path.join(worktreesDir(), slugify(project.name));
+      : path.join(worktreesDir(), toDirSlug(project.name));
     const worktreePath = path.join(baseDir, slug);
 
     // Prune stale worktree entries (e.g. leftover from a previous failed creation)
@@ -846,10 +838,10 @@ export class ProjectManager {
       );
     }
 
-    const slug = slugify(name);
+    const slug = toDirSlug(name);
     const baseDir = project.worktreePath
       ? expandHome(project.worktreePath)
-      : path.join(worktreesDir(), slugify(project.name));
+      : path.join(worktreesDir(), toDirSlug(project.name));
     const worktreePath = path.join(baseDir, slug);
 
     // Prune stale worktree entries

--- a/src/components/command-palette/GitHubIssueDetailView.tsx
+++ b/src/components/command-palette/GitHubIssueDetailView.tsx
@@ -8,6 +8,7 @@ import { stripMarkdown } from "./utils";
 import { IssueDetailSkeleton } from "./IssueDetailSkeleton";
 import type { CommandPaletteProps } from "./types";
 import { Row, Stack } from "../ui/Layout/Layout";
+import { sanitizeBranchName, branchesEqual } from "../../utils/branch-name";
 import styles from "./CommandPalette.module.css";
 
 type GitHubIssueDetailViewProps = {
@@ -21,14 +22,6 @@ type GitHubIssueDetailViewProps = {
   projectId?: string;
   workspacePath?: string;
 };
-
-function slugify(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-    .slice(0, 50);
-}
 
 export function GitHubIssueDetailView(props: GitHubIssueDetailViewProps) {
   const { repoPath, issueNumber, onBack, onClose, onNewWorkspace, onNewTaskWithPrompt, linkedTo, projectId, workspacePath } = props;
@@ -52,13 +45,13 @@ export function GitHubIssueDetailView(props: GitHubIssueDetailViewProps) {
     const project = findProject();
     if (!project) return;
 
-    const branchName = `${issueDetail.number}-${slugify(issueDetail.title)}`;
+    const branchName = `${issueDetail.number}-${sanitizeBranchName(issueDetail.title)}`;
 
     const current = useProjectStore
       .getState()
       .projects.find((p) => p.id === project.id);
     const existingIdx =
-      current?.workspaces.findIndex((ws) => ws.branch === branchName) ?? -1;
+      current?.workspaces.findIndex((ws) => branchesEqual(ws.branch, branchName)) ?? -1;
     if (existingIdx >= 0) {
       selectWorkspace(project.id, existingIdx);
       const existingWs = current?.workspaces[existingIdx];

--- a/src/components/command-palette/IssueDetailView.tsx
+++ b/src/components/command-palette/IssueDetailView.tsx
@@ -9,6 +9,7 @@ import { PRIORITY_LABELS, stripMarkdown, extractImages } from "./utils";
 import { IssueDetailSkeleton } from "./IssueDetailSkeleton";
 import type { CommandPaletteProps } from "./types";
 import { Row, Stack } from "../ui/Layout/Layout";
+import { branchesEqual } from "../../utils/branch-name";
 import styles from "./CommandPalette.module.css";
 
 type IssueDetailViewProps = {
@@ -50,8 +51,9 @@ export function IssueDetailView(props: IssueDetailViewProps) {
         .getState()
         .projects.find((p) => p.id === project.id);
       const existingIdx =
-        current?.workspaces.findIndex((ws) => ws.branch === issue.branchName) ??
-        -1;
+        current?.workspaces.findIndex((ws) =>
+          branchesEqual(ws.branch, issue.branchName),
+        ) ?? -1;
       if (existingIdx >= 0) {
         selectWorkspace(project.id, existingIdx);
         const existingWs = current?.workspaces[existingIdx];

--- a/src/components/sidebar/NewWorkspaceDialog/NewWorkspaceDialog.tsx
+++ b/src/components/sidebar/NewWorkspaceDialog/NewWorkspaceDialog.tsx
@@ -12,15 +12,7 @@ import { SearchableSelect } from "../../ui/SearchableSelect";
 import { ToggleGroup } from "../../ui/ToggleGroup";
 import styles from "./NewWorkspaceDialog.module.css";
 import { Row, Stack } from "../../ui/Layout/Layout";
-
-function slugify(str: string): string {
-  return str
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/[\s_]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-}
+import { sanitizeBranchName } from "../../../utils/branch-name";
 
 type Mode = "new" | "existing";
 
@@ -141,7 +133,7 @@ export function NewWorkspaceDialog(props: NewWorkspaceDialogProps) {
       e.preventDefault();
       setMode("new");
       setName(initialName);
-      setBranchName(initialBranch || slugify(initialName));
+      setBranchName(initialBranch || sanitizeBranchName(initialName));
       setBranchManuallyEdited(!!initialBranch);
       const proj = projects.find(
         (p) =>
@@ -208,7 +200,7 @@ export function NewWorkspaceDialog(props: NewWorkspaceDialogProps) {
         setError("Name must be 200 characters or fewer");
         return;
       }
-      const finalBranch = branchName.trim() || slugify(trimmedName);
+      const finalBranch = branchName.trim() || sanitizeBranchName(trimmedName);
       if (!finalBranch) {
         setError("Could not derive a valid branch name");
         return;
@@ -310,7 +302,7 @@ export function NewWorkspaceDialog(props: NewWorkspaceDialogProps) {
                         onChange={(e) => {
                           setName(e.target.value);
                           if (!branchManuallyEdited) {
-                            setBranchName(slugify(e.target.value));
+                            setBranchName(sanitizeBranchName(e.target.value));
                           }
                           setError(null);
                         }}

--- a/src/components/sidebar/ProjectSetupWizard/ProjectSetupWizard.tsx
+++ b/src/components/sidebar/ProjectSetupWizard/ProjectSetupWizard.tsx
@@ -10,16 +10,8 @@ import { DEFAULT_AGENT_COMMAND } from "../../../agent-defaults";
 import { Button } from "../../ui/Button/Button";
 import { Input, Textarea } from "../../ui/Input";
 import { Row, Stack } from "../../ui/Layout/Layout";
+import { toDirSlug } from "../../../utils/branch-name";
 import styles from "./ProjectSetupWizard.module.css";
-
-function slugify(str: string): string {
-  return str
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/[\s_]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-}
 
 function randomColor(): string | null {
   const colors = PROJECT_COLORS.filter((c) => c.value !== null);
@@ -86,7 +78,7 @@ export function ProjectSetupWizard(props: ProjectSetupWizardProps) {
     setAgentCommand("");
     setStartScript("");
     setCommands(project.commands ?? []);
-    const slug = slugify(project.name);
+    const slug = toDirSlug(project.name);
     setWorktreePath(`~/.manor/worktrees/${slug}`);
     worktreePathMatchesName.current = true;
     nameRef.current?.focus();
@@ -163,7 +155,7 @@ export function ProjectSetupWizard(props: ProjectSetupWizardProps) {
     (newName: string) => {
       setName(newName);
       if (worktreePathMatchesName.current) {
-        const slug = slugify(newName);
+        const slug = toDirSlug(newName);
         setWorktreePath(`~/.manor/worktrees/${slug}`);
       }
       // Debounce store update for sidebar

--- a/src/hooks/usePrWatcher.ts
+++ b/src/hooks/usePrWatcher.ts
@@ -1,4 +1,5 @@
 import { useProjectStore } from "../store/project-store";
+import { branchesEqual } from "../utils/branch-name";
 import { useMountEffect } from "./useMountEffect";
 
 const PR_POLL_INTERVAL = 15_000;
@@ -31,7 +32,7 @@ export async function fetchPrs() {
       );
 
       for (const [branch, pr] of results) {
-        const ws = nonMainWorkspaces.find((w) => w.branch === branch);
+        const ws = nonMainWorkspaces.find((w) => branchesEqual(w.branch, branch));
         if (ws) {
           updateWorkspacePr(
             ws.path,

--- a/src/store/project-store.ts
+++ b/src/store/project-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { useAppStore } from "./app-store";
 import { useToastStore } from "./toast-store";
+import { branchesEqual } from "../utils/branch-name";
 
 const COLLAPSED_KEY = "manor:collapsedProjectIds";
 const SIDEBAR_WIDTH_KEY = "manor:sidebarWidth";
@@ -439,7 +440,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     // Find the new workspace by name or branch.
     const branchName = branch || name;
     const newWs = updated.workspaces.find(
-      (ws) => !ws.isMain && (ws.name === name || ws.branch === branchName),
+      (ws) => !ws.isMain && (ws.name === name || branchesEqual(ws.branch, branchName)),
     );
     const wsPath = newWs?.path ?? null;
 
@@ -543,7 +544,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     }));
     // Find and select the new worktree workspace
     const newWs = updated.workspaces.find(
-      (ws) => !ws.isMain && ws.branch === branch,
+      (ws) => !ws.isMain && branchesEqual(ws.branch, branch),
     );
     const wsPath = newWs?.path ?? null;
     if (wsPath) {
@@ -685,7 +686,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         const wsIdx = p.workspaces.findIndex((ws) => ws.path === workspacePath);
         if (wsIdx === -1) return p;
         const ws = p.workspaces[wsIdx];
-        if (ws.branch === branch) return p;
+        if (branchesEqual(ws.branch, branch)) return p;
         const workspaces = [...p.workspaces];
         workspaces[wsIdx] = { ...ws, branch };
         return { ...p, workspaces };

--- a/src/utils/__tests__/branch-name.test.ts
+++ b/src/utils/__tests__/branch-name.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeBranchName,
+  toDirSlug,
+  branchesEqual,
+} from "../branch-name";
+
+describe("sanitizeBranchName", () => {
+  it("preserves case", () => {
+    expect(sanitizeBranchName("PROJ-123-MyFeature")).toBe("PROJ-123-MyFeature");
+  });
+
+  it("converts internal whitespace to hyphens", () => {
+    expect(sanitizeBranchName("My Feature")).toBe("My-Feature");
+  });
+
+  it("collapses whitespace runs to a single hyphen", () => {
+    expect(sanitizeBranchName("My   Big    Feature")).toBe("My-Big-Feature");
+  });
+
+  it("strips git-forbidden characters", () => {
+    const result = sanitizeBranchName("feat: do~thing?");
+    expect(result).not.toMatch(/[:~?]/);
+    expect(result).toBe("feat-dothing");
+  });
+
+  it("strips additional forbidden chars and sequences", () => {
+    const result = sanitizeBranchName("a^b*c[d\\e@{f}g");
+    expect(result).not.toMatch(/[\^*[\\@{}]/);
+  });
+
+  it("keeps slashes for namespaced branches", () => {
+    expect(sanitizeBranchName("feature/Foo Bar")).toBe("feature/Foo-Bar");
+  });
+
+  it("preserves case in namespaced branches", () => {
+    expect(sanitizeBranchName("user/PROJ-123")).toBe("user/PROJ-123");
+  });
+
+  it("removes a trailing .lock (case-insensitive)", () => {
+    expect(sanitizeBranchName("my-branch.lock")).toBe("my-branch");
+    expect(sanitizeBranchName("my-branch.LOCK")).toBe("my-branch");
+  });
+
+  it("trims leading and trailing separators", () => {
+    expect(sanitizeBranchName("  -/.My-Branch./-  ")).toBe("My-Branch");
+  });
+
+  it("collapses `..` to `.` and `//` to `/`", () => {
+    expect(sanitizeBranchName("feature//foo..bar")).toBe("feature/foo.bar");
+  });
+
+  it("collapses repeated hyphens", () => {
+    expect(sanitizeBranchName("foo---bar")).toBe("foo-bar");
+  });
+});
+
+describe("toDirSlug", () => {
+  it("lowercases and slugifies", () => {
+    expect(toDirSlug("PROJ-123 My Feature")).toBe("proj-123-my-feature");
+  });
+
+  it("strips disallowed characters", () => {
+    expect(toDirSlug("Hello, World!")).toBe("hello-world");
+  });
+});
+
+describe("branchesEqual", () => {
+  it("matches case-insensitively", () => {
+    expect(branchesEqual("MyBranch", "mybranch")).toBe(true);
+  });
+
+  it("returns false when values differ", () => {
+    expect(branchesEqual("foo", "bar")).toBe(false);
+  });
+
+  it("returns false when either value is null/undefined", () => {
+    expect(branchesEqual(null, "x")).toBe(false);
+    expect(branchesEqual("x", null)).toBe(false);
+    expect(branchesEqual(undefined, "x")).toBe(false);
+    expect(branchesEqual(null, null)).toBe(false);
+  });
+});

--- a/src/utils/branch-name.ts
+++ b/src/utils/branch-name.ts
@@ -1,0 +1,66 @@
+// Canonical branch-name and directory-slug helpers.
+//
+// `sanitizeBranchName` enforces `git check-ref-format` rules while preserving
+// the user's intended casing. `toDirSlug` produces a lowercase filesystem slug.
+// `branchesEqual` does case-insensitive matching (never feed its inputs to git).
+
+/**
+ * Enforce `git check-ref-format` rules while preserving case.
+ *
+ * - trims surrounding whitespace
+ * - converts internal whitespace runs to a single `-`
+ * - strips git-forbidden ref characters and the `@{`/`}` sequence chars
+ * - collapses `..` -> `.`, `//` -> `/`, repeated `-` -> `-`
+ * - keeps `/` so namespaced branches survive
+ * - trims leading/trailing `-`, `.`, `/`
+ * - drops a trailing `.lock` (case-insensitive)
+ * - does NOT lowercase
+ */
+export function sanitizeBranchName(input: string): string {
+  let result = input.trim();
+
+  // Internal whitespace runs -> single hyphen.
+  result = result.replace(/\s+/g, "-");
+
+  // Strip git-forbidden characters: ~ ^ : ? * [ \, the `{` `}` `@` sequence
+  // characters, and ASCII control chars.
+  // eslint-disable-next-line no-control-regex
+  result = result.replace(/[~^:?*[\\{}@\x00-\x1f\x7f]/g, "");
+
+  // Collapse repeated separators.
+  result = result.replace(/\.{2,}/g, ".");
+  result = result.replace(/\/{2,}/g, "/");
+  result = result.replace(/-{2,}/g, "-");
+
+  // Drop a trailing `.lock` (case-insensitive).
+  result = result.replace(/\.lock$/i, "");
+
+  // Trim leading/trailing separators.
+  result = result.replace(/^[-./]+|[-./]+$/g, "");
+
+  return result;
+}
+
+/**
+ * Lowercase filesystem slug. Ported from the existing `slugify`.
+ */
+export function toDirSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Case-insensitive equality, used only for matching — never for passing to git.
+ * Returns `false` if either value is null/undefined.
+ */
+export function branchesEqual(
+  a?: string | null,
+  b?: string | null,
+): boolean {
+  if (a == null || b == null) return false;
+  return a.toLowerCase() === b.toLowerCase();
+}


### PR DESCRIPTION
## Summary

Manor force-lowercased git branch names when creating a workspace. Entering a name with uppercase (e.g. an issue key like `PROJ-123`) produced a branch like `proj-123-…`, while some references retained the original casing — causing ref/path mismatch errors during workspace restore and cleanup, and breaking Jira/GitHub issue-key auto-linking.

This change **preserves the user's intended casing** in branch names and lowercases only filesystem directory slugs. Typing `PROJ-123 My Feature` now yields branch `PROJ-123-My-Feature` (case preserved) while the worktree directory stays lowercase.

Full rationale and tradeoffs in **ADR-144** (`docs/decisions/adr-144-preserve-branch-name-casing/`).

## What changed

- **New util `src/utils/branch-name.ts`** with three functions:
  - `sanitizeBranchName` — enforces `git check-ref-format` rules (strips forbidden chars, collapses separators, trims, drops trailing `.lock`, keeps `/` for namespaced branches) **while preserving case**.
  - `toDirSlug` — the existing lowercase filesystem slug, for directory names only.
  - `branchesEqual` — case-insensitive comparison, used for *matching* only (exact case is always passed to git/GitHub).
- **Removed all 3 duplicate `slugify()` definitions** in the renderer; wired 6 call sites (`NewWorkspaceDialog`, `GitHubIssueDetailView`, `IssueDetailView`, `ProjectSetupWizard`, `usePrWatcher`, `project-store`) to the util. Branch lookups now use `branchesEqual`, so external-API casing differences no longer cause silent lookup failures.
- **Electron side** (`electron/persistence.ts`): branches use `sanitizeBranchName`, directories use `toDirSlug`. Because `electron/` and `src/` are separate TS compile units (`rootDir: electron`) that can't share a module without a build restructure, a small `electron/branch-name.ts` mirrors the util (noted as a tradeoff in the ADR). `git worktree list` output remains the source of truth for a workspace's real branch and is never compared case-sensitively.

## Why preserve case

- No existing ADR mandates lowercasing; git ref names are case-sensitive and support uppercase.
- GitHub branch names are case-sensitive.
- Jira issue keys are uppercase by convention (`PROJ-123`); Jira DVCS / Smart-Commit and GitHub–Jira branch linking key off that token, so lowercasing breaks auto-linking.

## Verification

- ✅ `vite build` passes
- ✅ New util: 16/16 tests
- ✅ Full suite: 893 pass; the 6 failures are **identical on the base commit** (app-store, agent-status, task-navigation, etc.) — pre-existing and unrelated
- ✅ Type errors: 26 electron errors on base == 26 after the change (all pre-existing); zero new errors in `src` or `electron`

## Known limitation (out of scope, noted in ADR)

Case-only directory collisions (`MyFeature` vs `myfeature` → same lowercase dir slug) remain a pre-existing, rare edge case, left for follow-up.