### PR TITLE
fix(adr-144): resume prior agent session on relaunch instead of starting fresh

### DIFF
--- a/docs/decisions/adr-144-session-resume-on-relaunch/index.md
+++ b/docs/decisions/adr-144-session-resume-on-relaunch/index.md
@@ -1,6 +1,6 @@
 ---
 type: adr
-status: proposed
+status: accepted
 database:
   schema:
     status:

--- a/docs/decisions/adr-144-session-resume-on-relaunch/index.md
+++ b/docs/decisions/adr-144-session-resume-on-relaunch/index.md
@@ -1,0 +1,163 @@
+---
+type: adr
+status: proposed
+database:
+  schema:
+    status:
+      type: select
+      options: [todo, in-progress, review, done]
+      default: todo
+    priority:
+      type: select
+      options: [critical, high, medium, low]
+    assignee:
+      type: select
+      options: [opus, sonnet, haiku]
+  defaultView: board
+  groupBy: status
+---
+
+# ADR-144: Resume the prior agent session on relaunch instead of starting fresh
+
+## Context
+
+When Manor relaunches, persisted panes are reconciled against the running PTY
+daemon (`electron/terminal-host/layout-persistence.ts:219` `reconcile()`), which
+sorts each pane into one of three buckets:
+
+- **warm** — the daemon still holds the live PTY session. Manor reattaches to the
+  running process, so the agent (Claude/Codex/etc.) is *literally the same
+  process*. It looks perfectly resumed because it is.
+- **cold** — the daemon lost the session but a scrollback file exists. Manor
+  renders the old scrollback *text* into a brand-new PTY at the old cwd.
+- **fresh** — nothing survived; new PTY.
+
+For cold/fresh panes the agent process is gone. The renderer then runs the
+interrupted-task relaunch path in `src/hooks/useTerminalLifecycle.ts:287-299`:
+
+```ts
+const resumeTask = activeTasks.find(
+  (t) => t.paneId === paneId && !t.resumedAt && t.agentCommand,
+);
+...
+sendOnShellReady(resumeTask.agentCommand!);   // runs e.g. `claude --dangerously-skip-permissions` VERBATIM
+```
+
+This re-executes the *bare* agent command, which starts a **brand-new agent
+session** — the prior conversation is lost. This is why users see inconsistent
+behavior: warm restores keep the live session (great), but after a full machine
+reboot or daemon restart (cold/fresh) the session silently starts over.
+
+We already track everything needed to fix this:
+
+- `TaskInfo.agentSessionId` (`electron/task-persistence.ts:36`) is the agent
+  CLI's real session UUID (Claude's `session_id`, Codex's session id, etc.). It
+  is captured from the hook payload at `electron/hook-relay-effects.ts:112`
+  (`agentSessionId: effect.sessionId`), is **non-null by construction**, immutable,
+  and persisted to `~/.manor/tasks.json`.
+- A connector abstraction already exposes `getResumeCommand(baseCommand, sessionId)`
+  on every agent (`electron/agent-connectors.ts:26`).
+
+But that abstraction is **dead code** — `getResumeCommand` is defined and never
+called from anywhere in the codebase. And its current implementations have gaps:
+
+- **Claude** rebuilds from the binary only (`claude --resume <id>`), *dropping*
+  the user's flags like `--dangerously-skip-permissions` — so the resumed session
+  re-prompts for permissions.
+- **Codex** ignores the session id entirely and uses `codex resume --last`
+  (imprecise — resumes whatever the most-recent session was, not this pane's).
+- **opencode** has **no connector class at all**; `getConnector("opencode")`
+  falls back to the Claude connector, so it would emit `--resume`, which opencode
+  does not understand (opencode uses `--session <id>`).
+- **pi** uses `pi --session <id>` (plausible but unverified).
+
+### Why no `-r` picker fallback
+
+`agentSessionId` is non-null whenever a `TaskInfo` exists, and a `TaskInfo` only
+exists once the agent emitted a hook event. So in *every* case where resuming is
+meaningful, we have a concrete UUID. The only time we lack one is when there is no
+task at all (a pane that never ran an agent / a genuinely fresh shell) — and there
+the correct behavior is exactly today's: run the bare command. An interactive
+`-r` session picker is therefore unnecessary as an automatic fallback.
+
+## Decision
+
+Wire the existing connector resume abstraction into the relaunch path, and fix the
+abstraction so it is correct for all four agent kinds.
+
+### 1. Make `getResumeCommand` preserve flags + guard against double-append
+
+Change the contract from "rebuild from binary" to **"preserve the full base
+command and append the agent-specific resume flag."** This keeps user flags
+(`--dangerously-skip-permissions`, `--yolo`, model overrides, etc.). Add a shared
+guard so we never double-append when the base command already specifies resume.
+
+Per-agent resume syntax (verified against current CLIs, June 2026):
+
+| Agent    | Resume command                       | Existing resume tokens to detect (skip append) |
+|----------|--------------------------------------|------------------------------------------------|
+| claude   | `<base> --resume <id>`               | `--resume`, `-r`, `--continue`, `-c`           |
+| codex    | `<binary> resume <id>`               | `resume` subcommand                            |
+| opencode | `<base> --session <id>`              | `--session`, `-s`, `--continue`, `-c`          |
+| pi       | `<base> --session <id>`              | `--session`                                    |
+
+Notes:
+- `getResumeCommand` returns `null` when `sessionId` is empty (defensive; in
+  practice it is always present) so callers can fall back to the bare command.
+- Codex's resume is a *subcommand*, not a flag, and top-level flags like `--yolo`
+  don't compose cleanly after it — so codex stays a binary+`resume <id>` rebuild.
+  The approval-mode flag is not re-applied on codex resume; documented as a known
+  limitation (follow-up, not in scope).
+- Add a new **`OpencodeConnector`** and register it in `ensureDefaults()` so
+  opencode no longer falls through to Claude.
+
+### 2. Expose resume-command construction to the renderer over IPC
+
+Connectors live in the main process. Add `tasks:buildResumeCommand(taskId)` in
+`electron/ipc/tasks.ts`, mirroring the `tasks:markResumed` pattern. It looks up the
+task, calls `getConnector(task.agentKind).getResumeCommand(task.agentCommand,
+task.agentSessionId)`, and returns `string | null`. Surface it through
+`electron/preload.ts` and `src/electron.d.ts` as
+`tasks.buildResumeCommand(taskId): Promise<string | null>`.
+
+### 3. Use it in the relaunch path
+
+In `src/hooks/useTerminalLifecycle.ts`, replace the bare relaunch with the resume
+command, falling back to the bare command if the IPC returns `null`:
+
+```ts
+const resumeCmd = await window.electronAPI.tasks.buildResumeCommand(resumeTask.id);
+void window.electronAPI.tasks.markResumed(resumeTask.id);
+sendOnShellReady(resumeCmd ?? resumeTask.agentCommand!);
+```
+
+This is the *only* behavioral change to the recovery flow; warm restore is
+untouched.
+
+## Consequences
+
+**Better**
+- Cold/fresh-restored panes resume the actual prior conversation across machine
+  reboots and daemon restarts — matching the warm-restore experience.
+- Claude resumes keep `--dangerously-skip-permissions`, so no re-prompting.
+- opencode gets a real connector; codex resumes the *specific* pane's session.
+- The previously-dead `getResumeCommand` abstraction becomes live and tested.
+
+**Harder / risks**
+- **Claude session forking**: recent Claude versions fork a resumed session into a
+  *new* `session_id`. The relay handles this — the new SessionStart hook creates a
+  fresh `TaskInfo` (with the base `agentCommand` from pane context) and retires the
+  old pane task, while `resumedAt` on the old task prevents double-launch. The next
+  relaunch then resumes from the new session id. The chain is self-correcting, but
+  it means the resumed id differs from the original; acceptable.
+- **Codex approval mode** (`--yolo`) is not re-applied on resume; a codex pane may
+  re-prompt. Documented limitation, follow-up if it bites.
+- **pi** resume syntax (`--session`) is inherited from the existing connector and
+  remains unverified against a live pi CLI; low blast radius (returns a command
+  that, if wrong, the user sees immediately and can correct).
+- If `buildResumeCommand` ever returns `null` (no session id / unsupported agent),
+  behavior is exactly today's bare-command relaunch — no regression.
+
+## Tickets
+
+<div data-type="database" data-path="." data-view="board"></div>

--- a/docs/decisions/adr-144-session-resume-on-relaunch/ticket-1-fix-connector-resume.md
+++ b/docs/decisions/adr-144-session-resume-on-relaunch/ticket-1-fix-connector-resume.md
@@ -1,6 +1,6 @@
 ---
 title: Fix getResumeCommand to preserve flags, guard double-append, add OpencodeConnector
-status: in-progress
+status: done
 priority: critical
 assignee: sonnet
 blocked_by: []

--- a/docs/decisions/adr-144-session-resume-on-relaunch/ticket-1-fix-connector-resume.md
+++ b/docs/decisions/adr-144-session-resume-on-relaunch/ticket-1-fix-connector-resume.md
@@ -1,0 +1,67 @@
+---
+title: Fix getResumeCommand to preserve flags, guard double-append, add OpencodeConnector
+status: in-progress
+priority: critical
+assignee: sonnet
+blocked_by: []
+---
+
+# Fix connector `getResumeCommand` for all agent kinds
+
+Make the connector resume abstraction correct and complete. Today it is dead code
+with stale/missing implementations. See ADR-144 for full context.
+
+## Requirements
+
+1. **Add a shared helper** in `electron/agent-connectors.ts`:
+   ```ts
+   /** True if the command already specifies session resume, so we must not append again. */
+   function hasResumeToken(command: string, tokens: string[]): boolean {
+     const args = command.split(/\s+/);
+     return tokens.some((tok) => args.includes(tok));
+   }
+   ```
+   Match on whole space-delimited tokens (so `-c` does not match `--continue`, and a
+   path containing `resume` does not false-positive).
+
+2. **ClaudeConnector.getResumeCommand** — preserve the full base command and append:
+   - If `!sessionId` → return `null`.
+   - If `hasResumeToken(baseCommand, ["--resume", "-r", "--continue", "-c"])` → return `baseCommand` unchanged.
+   - Else → `` `${baseCommand} --resume ${sessionId}` ``.
+   - This MUST keep flags like `--dangerously-skip-permissions` (do NOT rebuild from the binary).
+
+3. **CodexConnector.getResumeCommand** — use the actual session id (not `--last`):
+   - If `!sessionId` → return `null`.
+   - If `hasResumeToken(baseCommand, ["resume"])` → return `baseCommand` unchanged.
+   - Else → `` `${binary} resume ${sessionId}` `` where `binary = baseCommand.split(" ")[0] ?? "codex"`.
+     (Codex resume is a subcommand; top-level flags like `--yolo` are intentionally
+     dropped — documented limitation in the ADR.)
+
+4. **Add `OpencodeConnector`** (new class implementing `AgentConnector`):
+   - `kind = "opencode"`, `defaultCommand = "opencode"`.
+   - `getResumeCommand`: if `!sessionId` → `null`; if
+     `hasResumeToken(baseCommand, ["--session", "-s", "--continue", "-c"])` → return
+     `baseCommand`; else → `` `${baseCommand} --session ${sessionId}` ``.
+   - `getPromptCommand`: same escaping pattern as the other connectors.
+   - `registerHooks` / `registerMcp`: no-op (opencode hook/MCP wiring is out of scope
+     for this ADR; leave empty bodies with a brief comment).
+   - Register it in `ensureDefaults()` alongside claude/codex/pi.
+
+5. **PiConnector.getResumeCommand** — apply the same preserve+guard shape:
+   - If `!sessionId` → `null`.
+   - If `hasResumeToken(baseCommand, ["--session"])` → return `baseCommand`.
+   - Else → `` `${baseCommand} --session ${sessionId}` ``.
+
+6. **Unit tests** in `electron/__tests__/` (new file `agent-connectors-resume.test.ts`)
+   covering, for each connector:
+   - Appends the correct resume flag with the session id.
+   - Preserves base flags (assert `--dangerously-skip-permissions` survives for claude).
+   - Returns the base command unchanged when a resume token is already present
+     (double-append guard) — test each guard token.
+   - Returns `null` for empty `sessionId`.
+   - `getConnector("opencode")` now returns the OpencodeConnector (not the Claude fallback).
+
+## Files to touch
+- `electron/agent-connectors.ts` — add `hasResumeToken`; rewrite `getResumeCommand`
+  for Claude/Codex/Pi; add `OpencodeConnector`; register it in `ensureDefaults()`.
+- `electron/__tests__/agent-connectors-resume.test.ts` — new test file (see above).

--- a/docs/decisions/adr-144-session-resume-on-relaunch/ticket-2-add-buildresumecommand-ipc.md
+++ b/docs/decisions/adr-144-session-resume-on-relaunch/ticket-2-add-buildresumecommand-ipc.md
@@ -1,6 +1,6 @@
 ---
 title: Add tasks:buildResumeCommand IPC bridging connector resume to the renderer
-status: todo
+status: done
 priority: critical
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-144-session-resume-on-relaunch/ticket-2-add-buildresumecommand-ipc.md
+++ b/docs/decisions/adr-144-session-resume-on-relaunch/ticket-2-add-buildresumecommand-ipc.md
@@ -1,0 +1,49 @@
+---
+title: Add tasks:buildResumeCommand IPC bridging connector resume to the renderer
+status: todo
+priority: critical
+assignee: sonnet
+blocked_by: [1]
+---
+
+# Add `tasks:buildResumeCommand` IPC
+
+Connectors live in the main process; the relaunch logic runs in the renderer. Add an
+IPC that computes the resume command for a task. See ADR-144.
+
+## Requirements
+
+1. **Main handler** in `electron/ipc/tasks.ts`, modeled on the existing
+   `tasks:markResumed` handler (around line 122):
+   ```ts
+   ipcMain.handle("tasks:buildResumeCommand", (_event, taskId: string) => {
+     assertString(taskId, "taskId");
+     const task = taskManager.getTaskById(taskId);
+     if (!task || !task.agentCommand) return null;
+     return getConnector(task.agentKind).getResumeCommand(
+       task.agentCommand,
+       task.agentSessionId,
+     );
+   });
+   ```
+   Import `getConnector` from `../agent-connectors` (add the import if absent).
+   Returns `string | null`.
+
+2. **Preload** in `electron/preload.ts`, next to `markResumed` (around line 364):
+   ```ts
+   buildResumeCommand: (taskId: string) =>
+     ipcRenderer.invoke("tasks:buildResumeCommand", taskId),
+   ```
+
+3. **Type** in `src/electron.d.ts`, next to `markResumed` (around line 548):
+   ```ts
+   buildResumeCommand: (taskId: string) => Promise<string | null>;
+   ```
+
+Do not change any resume behavior here — this ticket only exposes the connector
+result. Wiring happens in ticket 3.
+
+## Files to touch
+- `electron/ipc/tasks.ts` — add the `tasks:buildResumeCommand` handler + `getConnector` import.
+- `electron/preload.ts` — add `buildResumeCommand` to the tasks API surface.
+- `src/electron.d.ts` — add the `buildResumeCommand` signature to the tasks interface.

--- a/docs/decisions/adr-144-session-resume-on-relaunch/ticket-3-wire-resume-into-relaunch.md
+++ b/docs/decisions/adr-144-session-resume-on-relaunch/ticket-3-wire-resume-into-relaunch.md
@@ -1,0 +1,58 @@
+---
+title: Use buildResumeCommand in the relaunch path with bare-command fallback
+status: todo
+priority: critical
+assignee: sonnet
+blocked_by: [2]
+---
+
+# Wire resume into the relaunch path
+
+Replace the bare-command relaunch in the interrupted-task recovery branch so a
+cold/fresh-restored pane resumes its prior agent session. See ADR-144.
+
+## Requirements
+
+In `src/hooks/useTerminalLifecycle.ts`, the resume branch currently reads
+(around lines 287-299):
+
+```ts
+void (async () => {
+  const activeTasks = await window.electronAPI.tasks.getAll({ status: "active" });
+  const resumeTask = activeTasks.find(
+    (t) => t.paneId === paneId && !t.resumedAt && t.agentCommand,
+  );
+  if (!resumeTask || disposed) return;
+
+  // Mark resumed immediately to prevent double-launch on re-mount
+  void window.electronAPI.tasks.markResumed(resumeTask.id);
+
+  // Wait for shell prompt (CWD event), then relaunch
+  sendOnShellReady(resumeTask.agentCommand!);
+})();
+```
+
+Change the final two steps to build the resume command first, falling back to the
+bare agent command if it comes back `null`:
+
+```ts
+if (!resumeTask || disposed) return;
+
+// Mark resumed immediately to prevent double-launch on re-mount
+void window.electronAPI.tasks.markResumed(resumeTask.id);
+
+// Resume the prior agent session if we can; otherwise relaunch the bare command.
+const resumeCmd = await window.electronAPI.tasks.buildResumeCommand(resumeTask.id);
+if (disposed) return;
+sendOnShellReady(resumeCmd ?? resumeTask.agentCommand!);
+```
+
+Notes:
+- Keep `markResumed` BEFORE the `await` (preserves the existing double-launch guard
+  on re-mount).
+- Re-check `disposed` after the new `await`, consistent with the surrounding code.
+- No other branch of `useTerminalLifecycle` changes; warm restore is untouched.
+
+## Files to touch
+- `src/hooks/useTerminalLifecycle.ts` — swap the bare relaunch for the
+  `buildResumeCommand` result with a bare-command fallback.

--- a/docs/decisions/adr-144-session-resume-on-relaunch/ticket-3-wire-resume-into-relaunch.md
+++ b/docs/decisions/adr-144-session-resume-on-relaunch/ticket-3-wire-resume-into-relaunch.md
@@ -1,6 +1,6 @@
 ---
 title: Use buildResumeCommand in the relaunch path with bare-command fallback
-status: todo
+status: done
 priority: critical
 assignee: sonnet
 blocked_by: [2]

--- a/electron/__tests__/agent-connectors-resume.test.ts
+++ b/electron/__tests__/agent-connectors-resume.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ClaudeConnector,
+  CodexConnector,
+  PiConnector,
+  OpencodeConnector,
+  getConnector,
+} from "../agent-connectors";
+
+// ── ClaudeConnector ────────────────────────────────────────────────────────────
+
+describe("ClaudeConnector.getResumeCommand", () => {
+  const connector = new ClaudeConnector();
+  const sessionId = "abc-123";
+
+  it("appends --resume <sessionId> to the base command", () => {
+    const result = connector.getResumeCommand("claude", sessionId);
+    expect(result).toBe("claude --resume abc-123");
+  });
+
+  it("preserves flags like --dangerously-skip-permissions", () => {
+    const base = "claude --dangerously-skip-permissions";
+    const result = connector.getResumeCommand(base, sessionId);
+    expect(result).toBe("claude --dangerously-skip-permissions --resume abc-123");
+    expect(result).toContain("--dangerously-skip-permissions");
+  });
+
+  it("returns null for empty sessionId", () => {
+    expect(connector.getResumeCommand("claude", "")).toBeNull();
+  });
+
+  it("does not double-append when --resume is already present", () => {
+    const base = "claude --resume abc-123";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+
+  it("does not double-append when -r is already present", () => {
+    const base = "claude -r abc-123";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+
+  it("does not double-append when --continue is already present", () => {
+    const base = "claude --continue";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+
+  it("does not double-append when -c is already present", () => {
+    const base = "claude -c";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+
+  it("does not false-positive on a path containing resume", () => {
+    // A path token like /home/user/resume-project is not the same as --resume
+    const base = "claude --model claude-opus-4";
+    const result = connector.getResumeCommand(base, sessionId);
+    expect(result).toBe("claude --model claude-opus-4 --resume abc-123");
+  });
+});
+
+// ── CodexConnector ─────────────────────────────────────────────────────────────
+
+describe("CodexConnector.getResumeCommand", () => {
+  const connector = new CodexConnector();
+  const sessionId = "sess-456";
+
+  it("builds <binary> resume <sessionId> from the base command", () => {
+    const result = connector.getResumeCommand("codex", sessionId);
+    expect(result).toBe("codex resume sess-456");
+  });
+
+  it("uses the binary from a base command that includes --yolo", () => {
+    // Codex intentionally drops top-level flags; only the binary is kept
+    const result = connector.getResumeCommand("codex --yolo", sessionId);
+    expect(result).toBe("codex resume sess-456");
+  });
+
+  it("returns null for empty sessionId", () => {
+    expect(connector.getResumeCommand("codex", "")).toBeNull();
+  });
+
+  it("does not double-append when the resume subcommand is already present", () => {
+    const base = "codex resume sess-456";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+
+  it("uses only the binary from a base command with a custom path", () => {
+    const result = connector.getResumeCommand("/usr/local/bin/codex", sessionId);
+    expect(result).toBe("/usr/local/bin/codex resume sess-456");
+  });
+});
+
+// ── PiConnector ────────────────────────────────────────────────────────────────
+
+describe("PiConnector.getResumeCommand", () => {
+  const connector = new PiConnector();
+  const sessionId = "pi-789";
+
+  it("appends --session <sessionId> to the base command", () => {
+    const result = connector.getResumeCommand("pi", sessionId);
+    expect(result).toBe("pi --session pi-789");
+  });
+
+  it("preserves extra flags in the base command", () => {
+    const base = "pi --verbose";
+    const result = connector.getResumeCommand(base, sessionId);
+    expect(result).toBe("pi --verbose --session pi-789");
+    expect(result).toContain("--verbose");
+  });
+
+  it("returns null for empty sessionId", () => {
+    expect(connector.getResumeCommand("pi", "")).toBeNull();
+  });
+
+  it("does not double-append when --session is already present", () => {
+    const base = "pi --session pi-789";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+});
+
+// ── OpencodeConnector ──────────────────────────────────────────────────────────
+
+describe("OpencodeConnector.getResumeCommand", () => {
+  const connector = new OpencodeConnector();
+  const sessionId = "oc-abc";
+
+  it("appends --session <sessionId> to the base command", () => {
+    const result = connector.getResumeCommand("opencode", sessionId);
+    expect(result).toBe("opencode --session oc-abc");
+  });
+
+  it("preserves extra flags in the base command", () => {
+    const base = "opencode --model gpt-4o";
+    const result = connector.getResumeCommand(base, sessionId);
+    expect(result).toBe("opencode --model gpt-4o --session oc-abc");
+    expect(result).toContain("--model gpt-4o");
+  });
+
+  it("returns null for empty sessionId", () => {
+    expect(connector.getResumeCommand("opencode", "")).toBeNull();
+  });
+
+  it("does not double-append when --session is already present", () => {
+    const base = "opencode --session oc-abc";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+
+  it("does not double-append when -s is already present", () => {
+    const base = "opencode -s oc-abc";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+
+  it("does not double-append when --continue is already present", () => {
+    const base = "opencode --continue";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+
+  it("does not double-append when -c is already present", () => {
+    const base = "opencode -c";
+    expect(connector.getResumeCommand(base, sessionId)).toBe(base);
+  });
+});
+
+// ── OpencodeConnector kind and registry ───────────────────────────────────────
+
+describe("OpencodeConnector kind", () => {
+  it("has kind 'opencode'", () => {
+    const connector = new OpencodeConnector();
+    expect(connector.kind).toBe("opencode");
+  });
+
+  it("has defaultCommand 'opencode'", () => {
+    const connector = new OpencodeConnector();
+    expect(connector.defaultCommand).toBe("opencode");
+  });
+});
+
+describe("getConnector registry", () => {
+  it("returns OpencodeConnector (not Claude fallback) for 'opencode'", () => {
+    const connector = getConnector("opencode");
+    expect(connector.kind).toBe("opencode");
+    expect(connector).toBeInstanceOf(OpencodeConnector);
+  });
+
+  it("still returns ClaudeConnector for 'claude'", () => {
+    const connector = getConnector("claude");
+    expect(connector.kind).toBe("claude");
+    expect(connector).toBeInstanceOf(ClaudeConnector);
+  });
+
+  it("still returns CodexConnector for 'codex'", () => {
+    const connector = getConnector("codex");
+    expect(connector.kind).toBe("codex");
+    expect(connector).toBeInstanceOf(CodexConnector);
+  });
+
+  it("still returns PiConnector for 'pi'", () => {
+    const connector = getConnector("pi");
+    expect(connector.kind).toBe("pi");
+    expect(connector).toBeInstanceOf(PiConnector);
+  });
+});

--- a/electron/agent-connectors.ts
+++ b/electron/agent-connectors.ts
@@ -44,6 +44,17 @@ export interface AgentConnector {
   registerMcp(mcpServerScriptPath: string): void;
 }
 
+// ── Shared helpers ──
+
+/**
+ * True if the command already specifies session resume, so we must not append again.
+ * Matches on whole space-delimited tokens only, to avoid false positives.
+ */
+function hasResumeToken(command: string, tokens: string[]): boolean {
+  const args = command.split(/\s+/);
+  return tokens.some((tok) => args.includes(tok));
+}
+
 // ── Claude Code Connector ──
 
 const CLAUDE_HOOK_ENTRIES = [
@@ -65,11 +76,12 @@ export class ClaudeConnector implements AgentConnector {
   readonly kind: AgentKind = "claude";
   readonly defaultCommand = "claude --dangerously-skip-permissions";
 
-  getResumeCommand(baseCommand: string, sessionId: string): string {
-    // Extract the binary name (first token) — flags like --dangerously-skip-permissions
-    // aren't needed for resume since the session already has its config.
-    const binary = baseCommand.split(" ")[0] ?? "claude";
-    return `${binary} --resume ${sessionId}`;
+  getResumeCommand(baseCommand: string, sessionId: string): string | null {
+    if (!sessionId) return null;
+    if (hasResumeToken(baseCommand, ["--resume", "-r", "--continue", "-c"])) {
+      return baseCommand;
+    }
+    return `${baseCommand} --resume ${sessionId}`;
   }
 
   getPromptCommand(baseCommand: string, prompt: string): string {
@@ -186,11 +198,15 @@ export class CodexConnector implements AgentConnector {
   readonly kind: AgentKind = "codex";
   readonly defaultCommand = "codex --yolo";
 
-  getResumeCommand(baseCommand: string, _sessionId: string): string | null {
-    // Extract the binary name (first token) — flags like --yolo aren't needed for resume.
-    // Codex uses `codex resume --last` to resume the most recent session.
+  getResumeCommand(baseCommand: string, sessionId: string): string | null {
+    if (!sessionId) return null;
+    if (hasResumeToken(baseCommand, ["resume"])) {
+      return baseCommand;
+    }
+    // Codex resume is a subcommand; top-level flags like --yolo are intentionally
+    // dropped as they do not compose cleanly after the resume subcommand.
     const binary = baseCommand.split(" ")[0] ?? "codex";
-    return `${binary} resume --last`;
+    return `${binary} resume ${sessionId}`;
   }
 
   getPromptCommand(baseCommand: string, prompt: string): string {
@@ -338,9 +354,12 @@ export class PiConnector implements AgentConnector {
   readonly kind: AgentKind = "pi";
   readonly defaultCommand = "pi";
 
-  getResumeCommand(baseCommand: string, sessionId: string): string {
-    const binary = baseCommand.split(" ")[0] ?? "pi";
-    return `${binary} --session ${sessionId}`;
+  getResumeCommand(baseCommand: string, sessionId: string): string | null {
+    if (!sessionId) return null;
+    if (hasResumeToken(baseCommand, ["--session"])) {
+      return baseCommand;
+    }
+    return `${baseCommand} --session ${sessionId}`;
   }
 
   getPromptCommand(baseCommand: string, prompt: string): string {
@@ -501,6 +520,39 @@ export default function (pi: ExtensionAPI) {
   }
 }
 
+// ── Opencode Connector ──
+
+export class OpencodeConnector implements AgentConnector {
+  readonly kind: AgentKind = "opencode";
+  readonly defaultCommand = "opencode";
+
+  getResumeCommand(baseCommand: string, sessionId: string): string | null {
+    if (!sessionId) return null;
+    if (hasResumeToken(baseCommand, ["--session", "-s", "--continue", "-c"])) {
+      return baseCommand;
+    }
+    return `${baseCommand} --session ${sessionId}`;
+  }
+
+  getPromptCommand(baseCommand: string, prompt: string): string {
+    const escaped = prompt
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\$/g, "\\$")
+      .replace(/`/g, "\\`")
+      .replace(/!/g, "\\!");
+    return `${baseCommand} "${escaped}"`;
+  }
+
+  registerHooks(_hookScriptPath: string): void {
+    // opencode hook wiring is out of scope for ADR-144; no-op for now.
+  }
+
+  registerMcp(_mcpServerScriptPath: string): void {
+    // opencode MCP wiring is out of scope for ADR-144; no-op for now.
+  }
+}
+
 // ── Registry ──
 
 const connectors: Map<AgentKind, AgentConnector> = new Map();
@@ -510,9 +562,11 @@ function ensureDefaults(): void {
     const claude = new ClaudeConnector();
     const codex = new CodexConnector();
     const pi = new PiConnector();
+    const opencode = new OpencodeConnector();
     connectors.set(claude.kind, claude);
     connectors.set(codex.kind, codex);
     connectors.set(pi.kind, pi);
+    connectors.set(opencode.kind, opencode);
   }
 }
 

--- a/electron/ipc/tasks.ts
+++ b/electron/ipc/tasks.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from "electron";
+import { getConnector } from "../agent-connectors";
 import { assertString } from "../ipc-validate";
 import {
   getUnseenSnapshot,
@@ -124,6 +125,16 @@ export function register(deps: IpcDeps): void {
     return taskManager.updateTask(taskId, {
       resumedAt: new Date().toISOString(),
     });
+  });
+
+  ipcMain.handle("tasks:buildResumeCommand", (_event, taskId: string) => {
+    assertString(taskId, "taskId");
+    const task = taskManager.getTaskById(taskId);
+    if (!task || !task.agentCommand) return null;
+    return getConnector(task.agentKind).getResumeCommand(
+      task.agentCommand,
+      task.agentSessionId,
+    );
   });
 
   ipcMain.handle(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -362,6 +362,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ) => ipcRenderer.invoke("tasks:setPaneContext", paneId, context),
     markSeen: (taskId: string) => ipcRenderer.invoke("tasks:markSeen", taskId),
     markResumed: (taskId: string) => ipcRenderer.invoke("tasks:markResumed", taskId),
+    buildResumeCommand: (taskId: string) =>
+      ipcRenderer.invoke("tasks:buildResumeCommand", taskId),
     reconcileStale: () => ipcRenderer.invoke("tasks:reconcileStale"),
     abandonForPane: (paneId: string, title?: string | null) => ipcRenderer.invoke("tasks:abandonForPane", paneId, title),
     onUpdate: (

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -546,6 +546,7 @@ export interface ElectronAPI {
     ) => Promise<void>;
     markSeen: (taskId: string) => Promise<void>;
     markResumed: (taskId: string) => Promise<TaskInfo | null>;
+    buildResumeCommand: (taskId: string) => Promise<string | null>;
     reconcileStale: () => Promise<void>;
     abandonForPane: (paneId: string, title?: string | null) => Promise<void>;
     /**

--- a/src/hooks/useTerminalLifecycle.ts
+++ b/src/hooks/useTerminalLifecycle.ts
@@ -294,8 +294,10 @@ export function useTerminalLifecycle(
               // Mark resumed immediately to prevent double-launch on re-mount
               void window.electronAPI.tasks.markResumed(resumeTask.id);
 
-              // Wait for shell prompt (CWD event), then relaunch
-              sendOnShellReady(resumeTask.agentCommand!);
+              // Resume the prior agent session if we can; otherwise relaunch the bare command.
+              const resumeCmd = await window.electronAPI.tasks.buildResumeCommand(resumeTask.id);
+              if (disposed) return;
+              sendOnShellReady(resumeCmd ?? resumeTask.agentCommand!);
             })();
           }
         }


### PR DESCRIPTION
## Problem

On relaunch, cold/fresh-restored agent panes started a **brand-new session** instead of resuming the prior conversation. The recovery path (`useTerminalLifecycle.ts`) re-ran the agent command verbatim (e.g. `claude --dangerously-skip-permissions`) with no `--resume` appended.

This is why resume behaved inconsistently:
- **Warm restore** (daemon still holds the live PTY) → reattaches the *running* process, so it looks resumed because it is the same process.
- **Cold/fresh restore** (machine reboot, daemon restart) → process is gone, command re-run fresh → prior session lost.

We already track everything needed: `TaskInfo.agentSessionId` is the agent CLI's real session UUID (Claude's `session_id`), captured from the hook payload, non-null by construction, and persisted to `tasks.json`. And a connector `getResumeCommand(baseCommand, sessionId)` abstraction existed — but was **dead code**, never called, with stale/missing implementations.

## Changes

1. **`agent-connectors.ts`** — make `getResumeCommand` correct for all agents: *preserve* the user's flags and append the right resume syntax, with a `hasResumeToken` guard against double-append.
   - Claude: `--resume <id>` (now keeps `--dangerously-skip-permissions`)
   - Codex: `resume <id>` (was ignoring the id via `--last`)
   - pi: `--session <id>`
   - **new `OpencodeConnector`**: `--session <id>` (opencode had no connector and wrongly fell back to Claude's `--resume`)
2. **`tasks:buildResumeCommand` IPC** — bridges the main-process connectors to the renderer (preload + `electron.d.ts` types).
3. **`useTerminalLifecycle.ts`** — the relaunch path now resumes via the built command, falling back to the bare command if none is available. `markResumed` stays before the new await to preserve the double-launch guard.

No `-r` picker fallback: whenever a task exists to resume we always have the UUID; no task means a genuinely fresh shell where the bare command is already correct.

## Edge cases handled

- **Double-append**: skipped if the command already contains `--resume`/`-r`/`--continue`/`-c` (and per-agent equivalents).
- **Null fallback**: if `buildResumeCommand` returns `null`, behavior is exactly today's bare-command relaunch — no regression.

## Known limitations (documented in ADR)

- Claude forks the session id on resume in recent versions; the relay handles this and the chain self-corrects on the next relaunch.
- Codex's `--yolo` approval mode isn't re-applied on resume (resume is a subcommand, not a flag).
- pi's `--session` syntax is inherited and unverified against a live pi CLI.

## Testing

- 30 new unit tests for `getResumeCommand` across all four connectors (flag preservation, double-append guard per token, null on empty sessionId, opencode connector resolution).
- Full suite: 48 relevant tests pass, `vite build` clean, no new `tsc` errors (8 pre-existing, unrelated).

Full context: `docs/decisions/adr-144-session-resume-on-relaunch/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
