### PR TITLE
feat: detect project default branch from origin (ADR-144)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,6 +308,7 @@ Invariants are stated as absences — what the codebase deliberately does *not* 
 - **Renderer cannot write task lifecycle fields.** The `tasks:update` IPC allowlists fields the renderer may write (today: `name`). Lifecycle fields (`status`, `agentSessionId`, `lastAgentStatus`, `activatedAt`, `completedAt`, `resumedAt`, `paneId`) are owned by main; widening the allowlist is a deliberate decision, not a default. See ADR-136.
 - **Main is authoritative for unseen-flag state.** The `unseenRespondedTasks` / `unseenInputTasks` Sets in main drive the dock badge and the renderer's pulse animation. The renderer holds a cache populated from `tasks:getUnseen` (boot) and from the `task-updated` broadcast payload, which carries fresh flags on every update. The renderer never resets unseen state locally. Single send-site: `sendTaskUpdate` in `electron/notifications.ts`.
 - **Projects vs workspaces**: projects are directories, workspaces are git worktrees. A workspace's path can exist independently of the project (a worktree can be anywhere on disk); the project is the logical parent, not the filesystem parent.
+- **Default branch.** `project.defaultBranch` is a **bare local branch name** (e.g. `main`, never `origin/main`). It is detected from `origin/HEAD` at project creation and re-detected at startup (ADR-144). Consumers that need the remote ref prepend `origin/` at the use-site (ADR-081) — e.g. diff comparisons and new-worktree base points.
 
 ## Where to look next
 

--- a/docs/decisions/adr-144-detect-default-branch/index.md
+++ b/docs/decisions/adr-144-detect-default-branch/index.md
@@ -1,6 +1,6 @@
 ---
 type: adr
-status: proposed
+status: accepted
 database:
   schema:
     status:

--- a/docs/decisions/adr-144-detect-default-branch/index.md
+++ b/docs/decisions/adr-144-detect-default-branch/index.md
@@ -1,0 +1,122 @@
+---
+type: adr
+status: proposed
+database:
+  schema:
+    status:
+      type: select
+      options: [todo, in-progress, review, done]
+      default: todo
+    priority:
+      type: select
+      options: [critical, high, medium, low]
+    assignee:
+      type: select
+      options: [opus, sonnet, haiku]
+  defaultView: board
+  groupBy: status
+---
+
+# ADR-144: Detect the project's true default branch from origin
+
+## Context
+
+The project's `defaultBranch` is **hardcoded to `"main"`** at project creation —
+`electron/persistence.ts:180` (persisted `PersistedProject`) and `:233` (the
+`ProjectInfo` returned to the renderer). There is no detection of the repository's
+real upstream default branch anywhere: no `git symbolic-ref refs/remotes/origin/HEAD`,
+no `git remote show origin`, no `origin/HEAD` reference in `electron/` or `src/`.
+
+This single string is load-bearing. It seeds:
+
+- New Workspace dialog base-branch options — `NewWorkspaceDialog.tsx:80` and the
+  `allBranchOptions` list at `:104-113` (local default, `origin/{default}`, then other
+  `origin/*`).
+- Diff comparisons (`DiffPane`, `diff-watcher.ts` compare against `origin/<defaultBranch>`).
+- Merge targets and Quick Merge (`persistence.ts` merge ops; `workspace-actions.ts`).
+- The "Convert to Workspace" affordance (`ProjectItem.tsx`, gated on
+  `ws.branch !== project.defaultBranch`).
+
+So any repo whose upstream default is not literally `main` (`master`, `develop`,
+`trunk`, …) is silently mishandled across all of the above. The field is read-only in
+Project Settings (`ProjectSettingsPage.tsx:271`, `fieldStatic`) and is not in
+`ProjectUpdatableFields`, so today there is no way to even correct it.
+
+Because `defaultBranch` is always persisted (always written as `"main"`), presence /
+absence of the value cannot distinguish "never detected" from "genuinely main". That
+rules out a "skip resync if unrecorded" heuristic — and we don't need one: with the
+field staying read-only there is no user override to protect.
+
+This ADR **extends** prior decisions; it does not replace them:
+
+- **ADR-081** — base new worktrees off `origin/<defaultBranch>` (use-time behavior).
+- **ADR-092** — New Workspace dialog redesign; base-branch option ordering.
+- **ADR-065** — create workspaces from remote-only branches.
+
+All of those prepend `origin/` at use-sites; none of them establish what
+`defaultBranch` actually *is*. That gap is what this ADR closes.
+
+## Decision
+
+**1. Detect on project creation.** Add a `detectDefaultBranch(repoPath)` helper in
+`electron/persistence.ts` and call it from `addProject()`, replacing the hardcoded
+`"main"` at both `:180` and `:233`. Detection order (all local, no network fetch
+required — `origin/HEAD` is a local ref):
+
+1. `git symbolic-ref --short refs/remotes/origin/HEAD` → yields `origin/<name>`; strip
+   the `origin/` prefix to get the bare branch name.
+2. If unset, `git remote set-head origin --auto` then retry step 1 (this resolves
+   `origin/HEAD` from the remote; one cheap network round-trip, best-effort).
+3. Fall back to `"main"` only if everything fails (no remote, detached, offline).
+
+**2. Re-detect at startup as a failsafe.** Add `resyncDefaultBranches()` to
+`ProjectManager`. It iterates persisted projects, re-detects each project's default
+(local `symbolic-ref` only — no `set-head`/fetch, so it is fast and offline-safe),
+updates any that changed, and saves. It runs **once per session**, triggered lazily on
+the first `getProjects()` call (guarded by a `private resyncDone` flag) so the renderer's
+first `projects:getAll` already sees corrected values without a new IPC push event.
+
+Because the field is read-only (no user override), unconditional re-detection is safe:
+it auto-corrects existing projects stuck on `"main"` (drift) **and** picks up the case
+where origin's default changes later. Detection failures leave the stored value
+untouched (never clobber a good value with a fallback).
+
+**3. Keep the Project Settings field read-only — but truthful.** No UI change:
+`ProjectSettingsPage.tsx` keeps rendering `defaultBranch` as a static field. The value
+it shows is now detection-driven instead of a hardcoded lie. Manual override (a future
+"Override default branch" checkbox revealing a type-ahead picker over local + `origin/*`
+branches) is explicitly **deferred** — we design so as not to prevent it, but do not
+build it here.
+
+**4. Document the storage invariant.** `defaultBranch` is stored as a **bare local
+branch name**; `origin/` is prepended at use-sites (per ADR-081). Record this in
+`docs/ARCHITECTURE.md` and as a code comment near the field. Storing explicit
+local-vs-remote intent is out of scope.
+
+## Consequences
+
+**Better**
+- Repos with non-`main` defaults work correctly across diffs, merges, workspace
+  creation, and the Convert-to-Workspace affordance.
+- Existing projects self-heal on next launch with no migration step or user action.
+- Tracks upstream default-branch renames automatically.
+
+**Costs / risks**
+- `addProject` may make one best-effort network round-trip (`set-head --auto`) when
+  `origin/HEAD` is unset; guarded by try/catch and a `"main"` fallback so it never
+  blocks creation.
+- Startup `getProjects()` does N local `symbolic-ref` calls (one per project) on first
+  invocation. These are cheap and local, but we run them once per session, not per call.
+- Unconditional resync means a manual override is impossible until the deferred
+  checkbox lands — accepted by design (the repo default is the standard).
+
+**Non-goals (possible future work)**
+- Manual/local override of the default branch.
+- Offering local-only (non-default) branches as base options in New Workspace
+  "new branch" mode for WIP fork-points. Current `allBranchOptions`
+  (`NewWorkspaceDialog.tsx:104-113`) intentionally offers only local default + `origin/*`;
+  the local/origin optionality from ADR-092 is preserved as-is.
+
+## Tickets
+
+<div data-type="database" data-path="." data-view="board"></div>

--- a/docs/decisions/adr-144-detect-default-branch/ticket-1-detect-on-creation.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-1-detect-on-creation.md
@@ -1,6 +1,6 @@
 ---
 title: Detect default branch on project creation
-status: in-progress
+status: done
 priority: high
 assignee: sonnet
 blocked_by: []

--- a/docs/decisions/adr-144-detect-default-branch/ticket-1-detect-on-creation.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-1-detect-on-creation.md
@@ -1,0 +1,45 @@
+---
+title: Detect default branch on project creation
+status: in-progress
+priority: high
+assignee: sonnet
+blocked_by: []
+---
+
+# Detect default branch on project creation
+
+Replace the hardcoded `"main"` default branch with detection of the repo's real
+upstream default at project-add time.
+
+## Behavior
+
+Add a private async helper `detectDefaultBranch(repoPath: string): Promise<string | null>`
+to `ProjectManager` in `electron/persistence.ts`. It uses the existing `this.git.exec(cwd, args[])`
+backend (see `listLocalBranches`/`listRemoteBranches` for the pattern). Detection order:
+
+1. `git symbolic-ref --short refs/remotes/origin/HEAD`
+   - On success this returns `origin/<name>` (e.g. `origin/master`). **Strip the leading
+     `origin/` prefix** and return the bare name (`master`). This is a local ref read —
+     no network.
+2. If step 1 fails/empty: `git remote set-head origin --auto` (best-effort, one cheap
+   network round-trip), then retry step 1.
+3. If everything fails, return `null`.
+
+Trim stdout; treat empty string as failure. Wrap in try/catch and `console.error` on
+failure following the existing logging style in this file. Never throw out of the helper.
+
+Wire it into `addProject()`:
+- Compute `const detected = await this.detectDefaultBranch(projectPath);`
+- Use `detected ?? "main"` for the `defaultBranch` value in BOTH the persisted
+  `PersistedProject` object (currently `defaultBranch: "main"` at ~line 180) and the
+  returned `ProjectInfo` object (currently `defaultBranch: "main"` at ~line 233).
+  Compute it once and reuse the same variable in both places.
+
+Add a brief code comment at the `PersistedProject.defaultBranch` interface field (and/or
+the `ProjectInfo.defaultBranch` field) documenting the storage invariant:
+`// Bare local branch name (no "origin/" prefix). origin/ is prepended at use-sites — see ADR-081/144.`
+
+## Files to touch
+- `electron/persistence.ts` — add `detectDefaultBranch()` helper; call it in `addProject()`
+  and replace both hardcoded `"main"` assignments; add the invariant comment on the
+  `defaultBranch` field. Do not change unrelated logic.

--- a/docs/decisions/adr-144-detect-default-branch/ticket-2-startup-resync.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-2-startup-resync.md
@@ -1,0 +1,44 @@
+---
+title: Re-detect default branch at startup (drift failsafe)
+status: todo
+priority: high
+assignee: sonnet
+blocked_by: [1]
+---
+
+# Re-detect default branch at startup (drift failsafe)
+
+Auto-correct existing projects whose stored `defaultBranch` is stale (e.g. stuck on
+`"main"` from before detection existed, or origin's default was renamed). Safe to do
+unconditionally because the field is read-only — there is no user override to clobber.
+
+## Behavior
+
+Add a public method `resyncDefaultBranches(): Promise<void>` to `ProjectManager` in
+`electron/persistence.ts`:
+
+- Iterate `this.state.projects`.
+- For each project, re-detect using a **local-only** detection: run
+  `git symbolic-ref --short refs/remotes/origin/HEAD` directly (do NOT call
+  `set-head --auto`/fetch here — startup must stay fast and offline-safe). Reuse the
+  ticket-1 `detectDefaultBranch` helper but in a mode that skips the network step, OR
+  factor the local `symbolic-ref` read into a small shared `detectDefaultBranchLocal()`
+  helper that both `detectDefaultBranch` (step 1) and `resyncDefaultBranches` call.
+  Strip the `origin/` prefix as in ticket 1.
+- If detection returns a non-empty name that differs from `project.defaultBranch`,
+  update it. If detection fails/empty, leave the existing value untouched (never
+  overwrite a good value with a fallback).
+- If any project changed, call `this.saveState()` once at the end.
+- Wrap per-project detection in try/catch so one bad repo can't abort the sweep.
+
+Trigger it **once per session, lazily on first `getProjects()`**:
+- Add `private resyncDone = false;`
+- At the top of `getProjects()`, if `!this.resyncDone`, set `this.resyncDone = true`
+  and `await this.resyncDefaultBranches()` before building project info. This guarantees
+  the renderer's first `projects:getAll` returns corrected values without needing a new
+  IPC push event. Subsequent `getProjects()` calls skip the resync.
+
+## Files to touch
+- `electron/persistence.ts` — add `resyncDefaultBranches()` (and the local-only detection
+  helper if factoring it out), add the `resyncDone` guard, and invoke the resync at the
+  start of `getProjects()`.

--- a/docs/decisions/adr-144-detect-default-branch/ticket-2-startup-resync.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-2-startup-resync.md
@@ -1,6 +1,6 @@
 ---
 title: Re-detect default branch at startup (drift failsafe)
-status: todo
+status: in-progress
 priority: high
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-144-detect-default-branch/ticket-2-startup-resync.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-2-startup-resync.md
@@ -1,6 +1,6 @@
 ---
 title: Re-detect default branch at startup (drift failsafe)
-status: in-progress
+status: done
 priority: high
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-144-detect-default-branch/ticket-3-tests.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-3-tests.md
@@ -1,6 +1,6 @@
 ---
 title: Tests for default-branch detection and resync
-status: todo
+status: done
 priority: medium
 assignee: haiku
 blocked_by: [1, 2]

--- a/docs/decisions/adr-144-detect-default-branch/ticket-3-tests.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-3-tests.md
@@ -1,0 +1,44 @@
+---
+title: Tests for default-branch detection and resync
+status: todo
+priority: medium
+assignee: haiku
+blocked_by: [1, 2]
+---
+
+# Tests for default-branch detection and resync
+
+Add coverage in `electron/persistence.test.ts`. The existing tests already construct
+`ProjectManager` with a stubbed/mock git backend (see `new ProjectManager(stubGit, tmpDir)`
+and the `gitMock` usage around lines 25 / 279). Follow that pattern — the git stub's
+`exec(cwd, args)` should return canned stdout keyed on the args.
+
+## Cases to cover
+
+1. **Detect on creation — non-main default.** Stub `exec` so that
+   `symbolic-ref --short refs/remotes/origin/HEAD` returns `origin/master`. Assert
+   `addProject(...)` yields `defaultBranch === "master"` (prefix stripped) in the returned
+   `ProjectInfo`, and that the persisted state (reload a new `ProjectManager` from the same
+   `tmpDir`) also has `"master"`.
+
+2. **Detect on creation — fallback to main.** Stub `exec` so `symbolic-ref` rejects/returns
+   empty AND `set-head --auto` also fails. Assert `defaultBranch === "main"`.
+
+3. **Startup resync corrects drift.** Persist a project with `defaultBranch: "main"`
+   (e.g. via a manager whose git stub returned nothing useful), then construct a new
+   `ProjectManager` whose git stub returns `origin/develop` for `symbolic-ref`. Call
+   `getProjects()` and assert the returned project has `defaultBranch === "develop"`, and
+   that it was persisted (reload and re-check).
+
+4. **Resync does not clobber on detection failure.** Persist `defaultBranch: "trunk"`,
+   then `getProjects()` with a git stub where `symbolic-ref` fails. Assert the value
+   stays `"trunk"`.
+
+5. **Resync runs once.** Spy/count `symbolic-ref` invocations across two `getProjects()`
+   calls and assert the resync sweep only happened on the first call.
+
+Match the existing test framework/assertions used in the file (vitest-style `describe`/
+`it`/`expect`).
+
+## Files to touch
+- `electron/persistence.test.ts` — add the cases above, reusing existing stub/mock helpers.

--- a/docs/decisions/adr-144-detect-default-branch/ticket-4-document-invariant.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-4-document-invariant.md
@@ -1,0 +1,28 @@
+---
+title: Document the defaultBranch storage invariant
+status: done
+priority: low
+assignee: haiku
+blocked_by: []
+---
+
+# Document the defaultBranch storage invariant
+
+Record the rule that `defaultBranch` is stored as a bare local branch name and `origin/`
+is prepended at use-sites, so future contributors don't reintroduce ambiguity.
+
+## Behavior
+
+In `docs/ARCHITECTURE.md`, add a short note (near the existing ProjectManager / branch
+discussion) stating:
+
+> **Default branch.** `project.defaultBranch` is a **bare local branch name** (e.g.
+> `main`, never `origin/main`). It is detected from `origin/HEAD` at project creation and
+> re-detected at startup (ADR-144). Consumers that need the remote ref prepend `origin/`
+> at the use-site (ADR-081) — e.g. diff comparisons and new-worktree base points.
+
+Keep it concise; match the surrounding doc style. Do not touch `electron/persistence.ts`
+(the code comment for the invariant is handled in ticket 1).
+
+## Files to touch
+- `docs/ARCHITECTURE.md` — add the default-branch invariant note.

--- a/docs/decisions/adr-144-detect-default-branch/ticket-5-refresh-on-remote-touchpoint.md
+++ b/docs/decisions/adr-144-detect-default-branch/ticket-5-refresh-on-remote-touchpoint.md
@@ -1,0 +1,36 @@
+---
+title: Refresh origin/HEAD at remote network touchpoints
+status: done
+priority: medium
+assignee: opus
+blocked_by: [1, 2]
+---
+
+# Refresh origin/HEAD at remote network touchpoints
+
+Follow-up to the startup-resync decision. Startup re-detection is intentionally
+local-only (no network) so launch stays fast and offline-safe. The gap that leaves:
+an **upstream default-branch rename** is not picked up, because the local
+`origin/HEAD` symref only changes via `git remote set-head origin --auto` — a plain
+`git fetch` does **not** update an existing `origin/HEAD`.
+
+Rather than pay a network round-trip per project on every launch (with the attendant
+credential-prompt / hang risk), refresh `origin/HEAD` at a natural touchpoint where
+the app is already doing network git and the user expects latency: `listRemoteBranches`
+(invoked when the New Workspace dialog opens, and which already runs `fetch origin --prune`).
+
+## Behavior
+
+In `listRemoteBranches()` (`electron/persistence.ts`), after the existing
+`fetch origin --prune` and before the `for-each-ref`:
+
+1. Best-effort `git remote set-head origin --auto` (re-resolves the remote's HEAD symref).
+2. Re-detect via `detectDefaultBranchLocal(project.path)`.
+3. If it returns a non-empty name differing from `project.defaultBranch`, update and `saveState()`.
+
+The whole block is wrapped in its own try/catch and logs on failure — it must never
+block branch listing (which is the method's actual job). No `saveState()` when nothing
+changed.
+
+## Files to touch
+- `electron/persistence.ts` — add the refresh block inside `listRemoteBranches`.

--- a/electron/persistence.test.ts
+++ b/electron/persistence.test.ts
@@ -359,4 +359,123 @@ describe("ProjectManager", () => {
       );
     });
   });
+
+  describe("default branch detection and resync", () => {
+    function makeGit(
+      symbolicRefResult: string | Error,
+    ): GitBackend {
+      return {
+        exec: vi.fn(async (_cwd: string, args: string[]) => {
+          if (args[0] === "symbolic-ref") {
+            if (symbolicRefResult instanceof Error) throw symbolicRefResult;
+            return symbolicRefResult;
+          }
+          // All other git calls (set-head, worktree list, etc.): reject
+          // so graceful fallbacks kick in. listGitWorkspaces tolerates this.
+          throw new Error(`unstubbed git: ${args.join(" ")}`);
+        }),
+        worktreeAdd: vi.fn(),
+        worktreeList: vi.fn().mockResolvedValue([
+          { path: "/tmp/fake-project", branch: "main", isMain: true },
+        ]),
+        stage: vi.fn(),
+        unstage: vi.fn(),
+        discard: vi.fn(),
+        commit: vi.fn(),
+        stash: vi.fn(),
+        getFullDiff: vi.fn(),
+        getLocalDiff: vi.fn(),
+        getStagedFiles: vi.fn(),
+        worktreeRemove: vi.fn(),
+      } as unknown as GitBackend;
+    }
+
+    it("Detect on creation — non-main default", async () => {
+      const git = makeGit("origin/master\n");
+      const mgr = new ProjectManager(git, tmpDir);
+
+      const project = await mgr.addProject("Test", "/tmp/fake-project");
+
+      expect(project.defaultBranch).toBe("master");
+
+      // Reload and verify it persists
+      const reloaded = new ProjectManager(
+        makeGit("origin/master\n"),
+        tmpDir,
+      );
+      const projects = await reloaded.getProjects();
+      expect(projects).toHaveLength(1);
+      expect(projects[0].defaultBranch).toBe("master");
+    });
+
+    it("Detect on creation — fallback to main", async () => {
+      const git = makeGit(new Error("symbolic-ref failed"));
+      const mgr = new ProjectManager(git, tmpDir);
+
+      const project = await mgr.addProject("Test", "/tmp/fake-project");
+
+      expect(project.defaultBranch).toBe("main");
+    });
+
+    it("Startup resync corrects drift", async () => {
+      // Step 1: Create a project with "main" (symbolic-ref throws)
+      const gitThrows = makeGit(new Error("symbolic-ref failed"));
+      const mgr1 = new ProjectManager(gitThrows, tmpDir);
+      const created = await mgr1.addProject("Test", "/tmp/fake-project");
+      expect(created.defaultBranch).toBe("main");
+
+      // Step 2: Reload with a git that returns "develop"
+      const gitDevelop = makeGit("origin/develop\n");
+      const mgr2 = new ProjectManager(gitDevelop, tmpDir);
+      const projects = await mgr2.getProjects();
+
+      expect(projects).toHaveLength(1);
+      expect(projects[0].defaultBranch).toBe("develop");
+
+      // Step 3: Reload again and verify it persisted
+      const mgr3 = new ProjectManager(gitDevelop, tmpDir);
+      const projectsAgain = await mgr3.getProjects();
+      expect(projectsAgain[0].defaultBranch).toBe("develop");
+    });
+
+    it("Resync does not clobber on detection failure", async () => {
+      // Step 1: Create a project with "trunk"
+      const gitTrunk = makeGit("origin/trunk\n");
+      const mgr1 = new ProjectManager(gitTrunk, tmpDir);
+      const created = await mgr1.addProject("Test", "/tmp/fake-project");
+      expect(created.defaultBranch).toBe("trunk");
+
+      // Step 2: Reload with a git that throws on symbolic-ref
+      const gitThrows = makeGit(new Error("symbolic-ref failed"));
+      const mgr2 = new ProjectManager(gitThrows, tmpDir);
+      const projects = await mgr2.getProjects();
+
+      // Should still be "trunk"
+      expect(projects).toHaveLength(1);
+      expect(projects[0].defaultBranch).toBe("trunk");
+    });
+
+    it("Resync runs once", async () => {
+      const git = makeGit("origin/develop\n");
+      const mgr = new ProjectManager(git, tmpDir);
+      await mgr.addProject("Test", "/tmp/fake-project");
+
+      // Count symbolic-ref calls before first getProjects
+      const execMock = vi.mocked(git.exec);
+
+      // First getProjects should call resync
+      await mgr.getProjects();
+      const callsAfterFirst = execMock.mock.calls.filter(
+        (call) => call[1][0] === "symbolic-ref",
+      ).length;
+      expect(callsAfterFirst).toBeGreaterThan(0);
+
+      // Second getProjects should NOT call symbolic-ref again
+      await mgr.getProjects();
+      const callsAfterSecond = execMock.mock.calls.filter(
+        (call) => call[1][0] === "symbolic-ref",
+      ).length;
+      expect(callsAfterSecond).toBe(callsAfterFirst);
+    });
+  });
 });

--- a/electron/persistence.ts
+++ b/electron/persistence.ts
@@ -49,6 +49,7 @@ export interface ProjectInfo {
   id: string;
   name: string;
   path: string;
+  // Bare local branch name (no "origin/" prefix). origin/ is prepended at use-sites — see ADR-081/144.
   defaultBranch: string;
   workspaces: WorkspaceInfo[];
   selectedWorkspaceIndex: number;
@@ -88,6 +89,7 @@ interface PersistedProject {
   path: string;
   selectedWorkspaceIndex: number;
   workspaces: unknown[];
+  // Bare local branch name (no "origin/" prefix). origin/ is prepended at use-sites — see ADR-081/144.
   defaultBranch: string;
   defaultRunCommand: string | null;
   worktreePath: string | null;
@@ -169,15 +171,64 @@ export class ProjectManager {
     this.saveState();
   }
 
+  private async detectDefaultBranch(repoPath: string): Promise<string | null> {
+    try {
+      // Step 1: Read the local symbolic ref for origin/HEAD — no network needed.
+      let stdout = "";
+      try {
+        stdout = await this.git.exec(repoPath, [
+          "symbolic-ref",
+          "--short",
+          "refs/remotes/origin/HEAD",
+        ]);
+      } catch {
+        // Step 1 failed — try to set the remote HEAD pointer (one network round-trip).
+        try {
+          await this.git.exec(repoPath, ["remote", "set-head", "origin", "--auto"]);
+        } catch (setHeadErr) {
+          console.error(
+            "[ProjectManager] detectDefaultBranch: remote set-head failed:",
+            setHeadErr instanceof Error ? setHeadErr.message : setHeadErr,
+          );
+        }
+        // Retry step 1 after set-head.
+        try {
+          stdout = await this.git.exec(repoPath, [
+            "symbolic-ref",
+            "--short",
+            "refs/remotes/origin/HEAD",
+          ]);
+        } catch {
+          // Both attempts failed — return null and fall back to "main" at the call site.
+          return null;
+        }
+      }
+
+      const trimmed = stdout.trim();
+      if (!trimmed) return null;
+
+      // Strip the leading "origin/" prefix (e.g. "origin/master" → "master").
+      const prefix = "origin/";
+      return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed;
+    } catch (err) {
+      console.error(
+        "[ProjectManager] detectDefaultBranch failed:",
+        err instanceof Error ? err.message : err,
+      );
+      return null;
+    }
+  }
+
   async addProject(name: string, projectPath: string): Promise<ProjectInfo> {
     const id = crypto.randomUUID();
+    const detected = await this.detectDefaultBranch(projectPath);
     const project: PersistedProject = {
       id,
       name,
       path: projectPath,
       selectedWorkspaceIndex: 0,
       workspaces: [],
-      defaultBranch: "main",
+      defaultBranch: detected ?? "main",
       defaultRunCommand: null,
       worktreePath: null,
       worktreeStartScript: null,
@@ -230,7 +281,7 @@ export class ProjectManager {
       id,
       name,
       path: projectPath,
-      defaultBranch: "main",
+      defaultBranch: detected ?? "main",
       workspaces,
       selectedWorkspaceIndex: 0,
       defaultRunCommand: null,

--- a/electron/persistence.ts
+++ b/electron/persistence.ts
@@ -117,6 +117,7 @@ export class ProjectManager {
   private state: PersistedState;
   private dataDir: string;
   private git: GitBackend;
+  private resyncDone = false;
 
   constructor(git: GitBackend, dataDir?: string) {
     this.git = git;
@@ -157,6 +158,10 @@ export class ProjectManager {
   }
 
   async getProjects(): Promise<ProjectInfo[]> {
+    if (!this.resyncDone) {
+      this.resyncDone = true;
+      await this.resyncDefaultBranches();
+    }
     return Promise.all(
       this.state.projects.map((p) => this.buildProjectInfo(p)),
     );
@@ -171,51 +176,79 @@ export class ProjectManager {
     this.saveState();
   }
 
-  private async detectDefaultBranch(repoPath: string): Promise<string | null> {
+  /**
+   * LOCAL-ONLY: reads the symbolic ref for origin/HEAD with no network activity.
+   * Returns the bare branch name (e.g. "main") or null on any failure.
+   */
+  private async detectDefaultBranchLocal(repoPath: string): Promise<string | null> {
     try {
-      // Step 1: Read the local symbolic ref for origin/HEAD — no network needed.
-      let stdout = "";
-      try {
-        stdout = await this.git.exec(repoPath, [
-          "symbolic-ref",
-          "--short",
-          "refs/remotes/origin/HEAD",
-        ]);
-      } catch {
-        // Step 1 failed — try to set the remote HEAD pointer (one network round-trip).
-        try {
-          await this.git.exec(repoPath, ["remote", "set-head", "origin", "--auto"]);
-        } catch (setHeadErr) {
-          console.error(
-            "[ProjectManager] detectDefaultBranch: remote set-head failed:",
-            setHeadErr instanceof Error ? setHeadErr.message : setHeadErr,
-          );
-        }
-        // Retry step 1 after set-head.
-        try {
-          stdout = await this.git.exec(repoPath, [
-            "symbolic-ref",
-            "--short",
-            "refs/remotes/origin/HEAD",
-          ]);
-        } catch {
-          // Both attempts failed — return null and fall back to "main" at the call site.
-          return null;
-        }
-      }
-
+      const stdout = await this.git.exec(repoPath, [
+        "symbolic-ref",
+        "--short",
+        "refs/remotes/origin/HEAD",
+      ]);
       const trimmed = stdout.trim();
       if (!trimmed) return null;
-
       // Strip the leading "origin/" prefix (e.g. "origin/master" → "master").
       const prefix = "origin/";
       return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed;
+    } catch {
+      return null;
+    }
+  }
+
+  private async detectDefaultBranch(repoPath: string): Promise<string | null> {
+    try {
+      // Step 1: Read the local symbolic ref for origin/HEAD — no network needed.
+      const local = await this.detectDefaultBranchLocal(repoPath);
+      if (local) return local;
+
+      // Step 1 failed — try to set the remote HEAD pointer (one network round-trip).
+      try {
+        await this.git.exec(repoPath, ["remote", "set-head", "origin", "--auto"]);
+      } catch (setHeadErr) {
+        console.error(
+          "[ProjectManager] detectDefaultBranch: remote set-head failed:",
+          setHeadErr instanceof Error ? setHeadErr.message : setHeadErr,
+        );
+      }
+
+      // Retry step 1 after set-head.
+      return await this.detectDefaultBranchLocal(repoPath);
     } catch (err) {
       console.error(
         "[ProjectManager] detectDefaultBranch failed:",
         err instanceof Error ? err.message : err,
       );
       return null;
+    }
+  }
+
+  /**
+   * Re-detect the default branch for all persisted projects using local-only
+   * detection (no network). Updates any stale values and saves once if anything
+   * changed. Run once per session at first getProjects() call.
+   */
+  async resyncDefaultBranches(): Promise<void> {
+    let changed = false;
+    for (const project of this.state.projects) {
+      try {
+        const detected = await this.detectDefaultBranchLocal(project.path);
+        if (detected && detected !== project.defaultBranch) {
+          project.defaultBranch = detected;
+          changed = true;
+        }
+      } catch (err) {
+        // One bad repo must not abort the sweep.
+        console.error(
+          "[ProjectManager] resyncDefaultBranches: error for",
+          project.path,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+    if (changed) {
+      this.saveState();
     }
   }
 

--- a/electron/persistence.ts
+++ b/electron/persistence.ts
@@ -753,6 +753,29 @@ export class ProjectManager {
       // Fetch latest remote refs so for-each-ref has up-to-date data
       await this.git.exec(project.path, ["fetch", "origin", "--prune"]);
 
+      // Natural network touchpoint: refresh origin/HEAD (a plain fetch does NOT
+      // update it) so an upstream default-branch rename is picked up here rather
+      // than on every app launch, then resync this project's defaultBranch.
+      // Best-effort — must never block branch listing. See ADR-144.
+      try {
+        await this.git.exec(project.path, [
+          "remote",
+          "set-head",
+          "origin",
+          "--auto",
+        ]);
+        const detected = await this.detectDefaultBranchLocal(project.path);
+        if (detected && detected !== project.defaultBranch) {
+          project.defaultBranch = detected;
+          this.saveState();
+        }
+      } catch (err) {
+        console.error(
+          "[ProjectManager] listRemoteBranches: default-branch refresh failed:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+
       const stdout = await this.git.exec(project.path, [
         "for-each-ref",
         "--sort=-creatordate",


### PR DESCRIPTION
## Summary

Manor hardcoded `project.defaultBranch` to `"main"` at project creation — there was no detection of the repo's real upstream default. Any repo whose default is `master`/`develop`/`trunk`/etc. was silently mishandled across diffs, merges, New Workspace base-branch options, and the Convert-to-Workspace affordance.

This detects the true default from `origin/HEAD` and keeps it correct over time. The Project Settings field stays read-only but is now truthful. Full design record in `docs/decisions/adr-144-detect-default-branch/`.

## Changes

- **Detect on creation** — `detectDefaultBranch()`: reads `origin/HEAD` locally (`symbolic-ref --short refs/remotes/origin/HEAD`), falls back to a one-shot `git remote set-head origin --auto` network probe, strips the `origin/` prefix; falls back to `"main"` only if truly undetectable. Wired into `addProject()`.
- **Startup drift failsafe** — `resyncDefaultBranches()` runs once per session on first `getProjects()`, local-only (no network) so launch stays fast and offline-safe. Auto-corrects existing projects stuck on `"main"`. Never clobbers a good value on detection failure.
- **Upstream-rename refresh** — `listRemoteBranches()` (already fetches when the New Workspace dialog opens) now also runs `set-head --auto` + re-detect, so a renamed upstream default is picked up at a natural network touchpoint rather than on every launch. (A plain fetch does *not* update `origin/HEAD`.)
- **Invariant documented** — `defaultBranch` is stored as a bare local name; `origin/` is prepended at use-sites (ADR-081). Noted in `ARCHITECTURE.md` and inline.

## Non-goals (deferred)

- Manual/local override of the default branch (future "Override default branch" checkbox).
- Offering local-only WIP branches as base options in New Workspace "new branch" mode.

## Testing

- 5 new vitest cases (detect, fallback, drift correction, no-clobber, runs-once); `electron/persistence.test.ts` **28/28 pass**.
- `tsc --noEmit` clean for `electron/persistence.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
