### PR TITLE
ADR-145: correct window/link targeting & popup semantics in browser webviews

### DIFF
--- a/docs/decisions/adr-145-webview-window-targeting/index.md
+++ b/docs/decisions/adr-145-webview-window-targeting/index.md
@@ -1,6 +1,6 @@
 ---
 type: adr
-status: proposed
+status: accepted
 database:
   schema:
     status:

--- a/docs/decisions/adr-145-webview-window-targeting/index.md
+++ b/docs/decisions/adr-145-webview-window-targeting/index.md
@@ -1,0 +1,181 @@
+---
+type: adr
+status: proposed
+database:
+  schema:
+    status:
+      type: select
+      options: [todo, in-progress, review, done]
+      default: todo
+    priority:
+      type: select
+      options: [critical, high, medium, low]
+    assignee:
+      type: select
+      options: [opus, sonnet, haiku]
+  defaultView: board
+  groupBy: status
+---
+
+# ADR-145: Correct Window/Link Targeting & Popup Semantics in Browser Webviews
+
+## Context
+
+Manor embeds web content in browser panes using Electron `<webview>` tags
+(`src/components/workspace-panes/BrowserPane/BrowserPane.tsx`, one top-level
+`<webview src=...>` per pane). New-window behavior is currently implemented by
+**injecting JavaScript into every guest page** that overrides `window.open` and
+listens for `target="_blank"` anchor clicks
+(`electron/ipc/webview.ts`, `INTERCEPT_NEW_WINDOW_SCRIPT`). The injected script
+relays a URL back to the renderer over a `console.log` marker
+(`__manor_new_window__:`), which becomes a `webview:new-window` IPC message, which
+calls `addBrowserTab(url)` (`src/store/app-store.ts:647`).
+
+This was introduced in commit `41bd1a4` *"feat: open target=\"_blank\" links in
+new browser tabs"* — a deliberate but **narrow** feature (just `_blank` → new tab).
+The `window.open` override was bundled in as a catch-all written as
+`function(url){...}`, **dropping the second argument entirely**. ADR-119 later
+moved this code verbatim into `electron/ipc/webview.ts` without redesign. No ADR
+governs the targeting semantics.
+
+Two concrete bugs result, plus a class of unhandled cases:
+
+1. **`window.open(url, '_parent')` (and `_self`, `_top`) open a new tab instead of
+   navigating in place.** The injected override never reads the target, so every
+   `window.open` call — regardless of target — is flattened to "open a new manor
+   tab." Per the HTML spec these targets should navigate an *existing* browsing
+   context, not create one.
+
+2. **`window.open` from inside an `<iframe>` is silently dropped.** The intercept
+   script is injected via `executeJavaScript`, which runs in the **main frame
+   only**. Sub-frame `window.open` calls bypass the override and fall through to
+   Electron's native path; because the `<webview>` has no `allowpopups` attribute,
+   the native path blocks the open with no feedback.
+
+3. **No principled handling of popups, named targets, or opener-based
+   communication.** The override returns `null`, so any site relying on the
+   `WindowProxy` handle returned by `window.open` (OAuth/SSO popups, payment flows,
+   `postMessage`-coordinated auth) breaks: there is no handle to `postMessage` to,
+   no `window.opener` on the openee, no `window.close()`, and no named-target reuse.
+
+### The product question this ADR must answer
+
+Manor uses **per-project tabs** as its primary surface, so "new window → new tab"
+is the natural mapping for ordinary link navigation. But popups are not all
+ordinary navigation. There are two distinct intents hiding behind `window.open`:
+
+- **Navigation-style opens** — `target="_blank"` links, cmd/middle-click, plain
+  `window.open(url)` whose return value is ignored. The user just wants the page
+  somewhere new. **A manor tab is the correct home.**
+- **Communicating popups** — `window.open(url, name, "width=…,height=…")` used by
+  OAuth/SSO/payment flows. The opener *keeps the handle* and relies on a live
+  relationship: `popup.postMessage()`, `popup.closed`, `window.opener`,
+  `window.close()`, and reuse of the named context.
+
+**The hard constraint:** a manor tab is a *separate* top-level `<webview>` —
+a separate `WebContents` with its own frame tree. Chromium only wires up
+`window.opener` / a live `WindowProxy` / synchronous cross-document scripting when
+the new context is created through the **native window-open path within a
+compatible process**. There is no way to retrofit that relationship onto a manor
+tab created out-of-band over IPC. Therefore **"popup → manor tab" inherently
+cannot preserve opener communication.** Routing OAuth popups to tabs will keep
+breaking those flows no matter how we patch the injected script.
+
+This means correctness requires *routing by intent*, which in turn requires the
+metadata only Electron's **native** open path exposes — `disposition`,
+`frameName`, and `features` — none of which the injected-JS approach can see.
+
+## Decision
+
+**Replace the injected-JS interception with Electron's native
+`setWindowOpenHandler` on the guest `WebContents`, and route opens by intent.**
+Remove `INTERCEPT_NEW_WINDOW_SCRIPT` and its console-message listener entirely.
+
+### 1. Enable the native open path
+
+Add the `allowpopups` attribute to the `<webview>` in `BrowserPane.tsx`. Without
+it, the guest's `window.open` is blocked before `setWindowOpenHandler` ever fires
+(this is the root of bug #2). With it present, **we control every open decision in
+the handler** — `allowpopups` does not mean "allow everything," it means "let the
+open request reach our handler."
+
+### 2. Register `setWindowOpenHandler` in `webview:register`
+
+In `electron/ipc/webview.ts`, where we already attach context-menu / escape /
+console listeners to the guest `wc`, register a window-open handler. It receives
+`{ url, frameName, features, disposition }` and routes:
+
+| Signal | Meaning | Action |
+|---|---|---|
+| `disposition: foreground-tab` / `background-tab` (plain `_blank` link, cmd/middle-click, `window.open` w/o features) | navigation-style | `{action:'deny'}` + relay `webview:new-window` → manor tab. Pass `background` so cmd-click does not steal focus. |
+| `disposition: new-window` **and/or** a `features` string present (`width`/`height`/`popup`) | communicating popup (OAuth/SSO/payment) | `{action:'allow', overrideBrowserWindowOptions:{…}}` → real managed child window with `window.opener`, `postMessage`, `closed`, `close()`, named reuse all wired natively. |
+| `_self` / `_parent` / `_top` / in-page nav | same/ancestor frame navigation | **Never reaches `setWindowOpenHandler`** — these are `will-navigate`, handled natively by the guest. Removing the JS override is what fixes bug #1. No manor code needed. |
+
+The exact `disposition` values Electron emits for each gesture on a `<webview>`
+must be confirmed by a short spike before finalizing the routing table (see
+Ticket 1 acceptance criteria) — the table above is the intended mapping, not an
+assumed fact.
+
+### 3. Managed child window for communicating popups
+
+For the `allow` branch, create an owned child `BrowserWindow` (parented to the
+main window) so OAuth/SSO/payment flows work end-to-end. Track child windows and
+destroy them when the originating pane is unregistered or the main window closes.
+This is the only way to preserve the Chromium opener relationship the flows depend
+on. (`overrideBrowserWindowOptions` lets us size/style it; `did-create-window`
+gives us the child `WebContents` for tracking and for applying the same external-
+link policy as the main window.)
+
+### 4. Frame-to-frame & tab-to-tab communication — explicit semantics
+
+- **Frame-to-frame** (iframe targeting `_parent`/`_top`, or a named sibling frame
+  *inside the same page*): stays entirely within the guest's own frame tree.
+  Manor must **not** intercept it or escalate it to a tab — naively treating
+  `_parent` as "navigate the webview's top URL" would break legitimate
+  iframe→parent navigation. Native pass-through handles this correctly.
+- **Tab-to-tab** (manor tab → manor tab): **not supported, by design.** Independent
+  `<webview>` tabs have no opener relationship; `window.opener`, handle
+  `postMessage`, and named-target reuse across tabs are not available. This is the
+  status quo and the documented limitation. Sites that genuinely need it get a
+  real child window via the popup path (#3), not a tab.
+
+### 5. Thread `disposition` through the existing IPC
+
+Extend `webview:new-window` (preload + `electron.d.ts` + `BrowserPane` listener)
+to carry a `background` flag, and extend `addBrowserTab(url, { background })` in
+`app-store.ts` so `background-tab` opens create a tab without stealing focus.
+Default stays foreground for backward compatibility (the image context-menu
+"Open Image in New Tab" path and all existing `addBrowserTab` callers keep working
+unchanged).
+
+## Consequences
+
+**Better:**
+- `window.open(url, '_parent' | '_self' | '_top')` navigates in place (bug #1 fixed)
+  — and it's fixed by *removing* code, not adding a special case.
+- `window.open` from iframes works (bug #2 fixed) — the native handler fires for
+  all frames, not just the main frame.
+- OAuth/SSO/payment popups work, with a real opener relationship (new capability).
+- cmd/middle-click can open background tabs without focus theft.
+- Less injected JS running in every guest page; decisions move to a single typed
+  handler with authoritative metadata.
+
+**Harder / risks:**
+- Adds a managed child-window lifecycle (creation, tracking, cleanup on pane
+  unregister / window close). Leaks here mean orphaned windows.
+- `allowpopups` must be paired with a correct handler or it would let guests open
+  windows freely — the handler is now load-bearing for security, not just UX.
+- Exact `disposition`/`features` values on `<webview>` need verification across the
+  Electron version in use; the routing table is intent, pending the Ticket 1 spike.
+- Popup *window features* (size/position) are best-effort; manor may normalize them.
+- Named-target reuse across manor tabs remains unsupported (documented limitation).
+
+**Open product decision (to confirm at approval):** whether communicating popups
+should open as a **real child window** (recommended — preserves opener semantics,
+makes OAuth work) or be **forced into a manor tab** (simpler, consistent tab UX,
+but knowingly breaks handle-dependent flows). The decision above assumes the
+former; Ticket 3 is scoped to it and can be dropped if we accept the limitation.
+
+## Tickets
+
+<div data-type="database" data-path="." data-view="board"></div>

--- a/docs/decisions/adr-145-webview-window-targeting/index.md
+++ b/docs/decisions/adr-145-webview-window-targeting/index.md
@@ -176,6 +176,36 @@ makes OAuth work) or be **forced into a manor tab** (simpler, consistent tab UX,
 but knowingly breaks handle-dependent flows). The decision above assumes the
 former; Ticket 3 is scoped to it and can be dropped if we accept the limitation.
 
+## Validation (2026-06-16)
+
+Validated live in a dev build using `tests/manual/window-targeting.html` (driven
+by hand, observed via the webview MCP + on-page log). The full matrix passed:
+
+- **A** anchor targets: `_blank` → foreground tab, cmd/middle-click → background
+  tab (no focus theft), `_self`/`_top`/`_parent` → in-place navigation.
+- **B** `window.open`: no-target/`_blank`/named → tabs; `_self`/`_parent`/`_top`
+  → in place (the original reported bug, fixed).
+- **C** communicating popup: opens a separate managed child window, with a live
+  `window.opener`, bidirectional `postMessage`, and `close()` from both opener
+  and popup (`popup.closed` reflects it) — the OAuth/SSO path works end-to-end.
+- **D** iframe: `window.open`/`target=_blank` → tab (bug #2, fixed), `_parent`/
+  `_top` navigate within the page's frame tree (never a tab), `parent.postMessage`
+  stays internal.
+- **E** same-page named frames: frame self-nav, frame↔frame `postMessage`, and
+  named-sibling targeting all stay in-page (not intercepted). Named-tab reuse
+  across `<webview>` tabs is confirmed **unsupported** (each `window.open(url,
+  name)` from the top frame makes a fresh tab) — the documented limitation.
+
+**Regression found and fixed during validation:** ticket 1 set `allowpopups` as a
+boolean prop (`allowpopups={true}`), which **React 19 silently drops for
+`<webview>`**, leaving the attribute absent — so Electron blocked every guest
+`window.open`/`target=_blank` *before* `setWindowOpenHandler` ran, making the
+whole feature a no-op. typecheck/build/unit tests were all green; only running the
+real app surfaced it. Fixed by emitting `allowpopups` as a string attribute
+(commit `fix(browser): emit webview allowpopups as a string attribute`). This is
+exactly the live-run the ticket-1 spike note called for; the `disposition` routing
+table is now confirmed against the running Electron build.
+
 ## Tickets
 
 <div data-type="database" data-path="." data-view="board"></div>

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-1-native-window-open-handler.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-1-native-window-open-handler.md
@@ -1,0 +1,71 @@
+---
+title: Replace injected-JS interception with native setWindowOpenHandler
+status: in-progress
+priority: critical
+assignee: opus
+blocked_by: []
+---
+
+# Replace injected-JS interception with native setWindowOpenHandler
+
+Foundational change. Move new-window decisions from the injected
+`INTERCEPT_NEW_WINDOW_SCRIPT` to Electron's native `setWindowOpenHandler` on the
+guest `WebContents`, and remove the injected script. This single change fixes
+bug #1 (`_parent`/`_self`/`_top` hijacked into new tabs) and bug #2 (iframe
+`window.open` silently dropped).
+
+## Spike first (acceptance gate)
+
+Before finalizing the routing table, verify on the project's Electron version,
+inside a `<webview>` with `allowpopups`, what `disposition` and `features` values
+`setWindowOpenHandler` actually receives for:
+- a plain `<a target="_blank">` click
+- a cmd/ctrl+click and a middle-click
+- `window.open(url)` with no features
+- `window.open(url, '_blank', 'width=500,height=600')`
+- `window.open(url, '_parent')` and `'_self'` / `'_top'` (confirm these do NOT
+  reach the handler — they should be `will-navigate` instead)
+- `window.open` called from inside an `<iframe>` (confirm the handler now fires)
+
+Record the observed mapping in a comment next to the handler so the routing is
+documented, not assumed.
+
+## Implementation
+
+1. **Enable the native open path.** Add the `allowpopups` attribute to the
+   `<webview>` element so guest `window.open` requests reach our handler instead
+   of being blocked. The handler (below) is now the sole authority on what opens.
+
+2. **Register `setWindowOpenHandler`** on the guest `wc` inside the
+   `webview:register` handler, alongside the existing context-menu / escape /
+   console listeners. Route by intent:
+   - **Navigation-style** (`disposition` `foreground-tab` / `background-tab`, i.e.
+     `_blank` links, cmd/middle-click, featureless `window.open`): return
+     `{ action: "deny" }` and `rendererWebContents.send("webview:new-window",
+     paneId, url, { background: disposition === "background-tab" })`. (Ticket 2
+     consumes the `background` flag; send it now.)
+   - **Communicating popup** (`disposition: "new-window"` and/or a non-empty
+     `features` string): return `{ action: "deny" }` **for now** with a clear
+     `TODO(ticket-3)` — Ticket 3 replaces this branch with the managed child
+     window. Do not silently route popups to tabs.
+
+3. **Remove the injected interception.** Delete `INTERCEPT_NEW_WINDOW_SCRIPT`, the
+   `did-finish-load` injection (`injectNewWindowIntercept`), and the
+   `console-message` listener that parses `__manor_new_window__:`. Update the
+   `webview:unregister` cleanup (`newWindowConsoleCleanup`) accordingly — replace
+   it with cleanup for the new handler if any teardown is needed (note:
+   `setWindowOpenHandler` is replaced, not removed; clearing it on unregister is
+   optional since the `wc` is going away, but remove the now-dead cleanup map).
+   Keep the image context-menu "Open Image in New Tab" path
+   (`webview.ts:74-81`) intact — it still sends `webview:new-window`.
+
+## Files to touch
+- `electron/ipc/webview.ts` — register `setWindowOpenHandler` with intent-based
+  routing; delete `INTERCEPT_NEW_WINDOW_SCRIPT`, `injectNewWindowIntercept`, the
+  `console-message` new-window listener, and the `newWindowConsoleCleanup` map.
+- `src/components/workspace-panes/BrowserPane/BrowserPane.tsx` — add `allowpopups`
+  to the `<webview>` element (~line 524).
+
+## Out of scope
+- Background-tab focus handling end-to-end (Ticket 2 consumes the flag).
+- The managed child window for popups (Ticket 3).

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-1-native-window-open-handler.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-1-native-window-open-handler.md
@@ -1,6 +1,6 @@
 ---
 title: Replace injected-JS interception with native setWindowOpenHandler
-status: in-progress
+status: done
 priority: critical
 assignee: opus
 blocked_by: []

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-2-background-tab-disposition.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-2-background-tab-disposition.md
@@ -1,0 +1,48 @@
+---
+title: Thread background-tab disposition through new-window IPC
+status: todo
+priority: high
+assignee: sonnet
+blocked_by: [1]
+---
+
+# Thread background-tab disposition through new-window IPC
+
+Ticket 1 sends a `{ background }` flag with `webview:new-window` for cmd/middle-
+click opens. Wire that flag through to tab creation so background-tab opens do not
+steal focus, while keeping foreground the default for all existing callers.
+
+## Implementation
+
+1. **Preload** (`electron/preload.ts:454-462`): extend `onNewWindow` so the
+   callback receives the optional `{ background }` payload sent by the main
+   process. Keep it backward-compatible (absent → foreground).
+
+2. **Types** (`src/electron.d.ts:607`): update the `onNewWindow` signature to
+   include the optional `background` argument/flag.
+
+3. **BrowserPane** (`src/components/workspace-panes/BrowserPane/BrowserPane.tsx`
+   ~438-443): pass the flag into the store call —
+   `addBrowserTab(openUrl, { background })`.
+
+4. **Store** (`src/store/app-store.ts:235` interface, `:647` impl): change
+   `addBrowserTab(url)` to `addBrowserTab(url, opts?: { background?: boolean })`.
+   When `background` is true, create the tab but do **not** set it as
+   `selectedTabId` (leave the current selection). Default/absent → current
+   behavior (create and select). Verify all existing callers still compile —
+   they call `addBrowserTab(url)` with one arg and must keep foreground behavior:
+   - `src/App.tsx:320`
+   - `src/components/sidebar/WorkspaceEmptyState.tsx:195`
+   - `src/components/tabbar/TabBar/TabBar.tsx:409`
+   - `src/components/command-palette/useCommands.tsx:115,421` (and the
+     `addBrowserTab` type in `useCommands.tsx:29`)
+   - `src/components/ports/PortBadge.tsx:21`
+
+## Files to touch
+- `electron/preload.ts` — extend `onNewWindow` payload.
+- `src/electron.d.ts` — update `onNewWindow` type.
+- `src/components/workspace-panes/BrowserPane/BrowserPane.tsx` — pass `background`.
+- `src/store/app-store.ts` — `addBrowserTab(url, { background })`, skip selection
+  when background; update the store interface type.
+- `src/components/command-palette/useCommands.tsx` — update the `addBrowserTab`
+  prop type if it constrains the signature.

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-2-background-tab-disposition.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-2-background-tab-disposition.md
@@ -1,6 +1,6 @@
 ---
 title: Thread background-tab disposition through new-window IPC
-status: in-progress
+status: done
 priority: high
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-2-background-tab-disposition.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-2-background-tab-disposition.md
@@ -1,6 +1,6 @@
 ---
 title: Thread background-tab disposition through new-window IPC
-status: todo
+status: in-progress
 priority: high
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-3-managed-child-window-popups.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-3-managed-child-window-popups.md
@@ -1,6 +1,6 @@
 ---
 title: Managed child window for communicating popups (OAuth/SSO/payment)
-status: todo
+status: in-progress
 priority: high
 assignee: opus
 blocked_by: [1]

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-3-managed-child-window-popups.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-3-managed-child-window-popups.md
@@ -1,0 +1,54 @@
+---
+title: Managed child window for communicating popups (OAuth/SSO/payment)
+status: todo
+priority: high
+assignee: opus
+blocked_by: [1]
+---
+
+# Managed child window for communicating popups
+
+Replace the `TODO(ticket-3)` deny branch from Ticket 1 with a real, owned child
+`BrowserWindow` so popups that depend on the opener relationship work end-to-end:
+`window.opener`, `popup.postMessage()`, `popup.closed`, `window.close()`, and
+named-target reuse. This is the only mechanism that preserves the Chromium opener
+relationship — it cannot be emulated with a manor tab.
+
+## Implementation
+
+1. **Allow the open in `setWindowOpenHandler`** for the communicating-popup branch
+   (`disposition: "new-window"` and/or non-empty `features`): return
+   `{ action: "allow", overrideBrowserWindowOptions: { ... } }`. Parent the child
+   to the main `BrowserWindow` (`parent`), set a sensible default size, and
+   normalize/clamp any requested `features` size. Configure secure `webPreferences`
+   consistent with the rest of the app (contextIsolation on, nodeIntegration off,
+   sandbox on) — match `electron/window.ts` defaults.
+
+2. **Track child windows.** Use the `did-create-window` event (or the handler's
+   `createWindow` callback) to capture the child `BrowserWindow` / its
+   `WebContents`. Keep a registry keyed by originating `paneId` so children can be
+   cleaned up. Apply the same external-link policy as the main window — give the
+   child's `webContents` a `setWindowOpenHandler` that routes *its* further
+   `window.open`s sensibly (e.g. `shell.openExternal` for http/https like
+   `electron/window.ts:120`, to avoid unbounded popup chains).
+
+3. **Lifecycle / cleanup.** Destroy or close tracked child windows when:
+   - the originating pane is unregistered (`webview:unregister`), and
+   - the main window closes.
+   Ensure no orphaned windows or listener leaks. Remove registry entries on the
+   child's `closed` event.
+
+4. **Verify opener semantics** with a manual or scripted check: opener can
+   `postMessage` to the child and observe `child.closed` flip after the child
+   calls `window.close()`. A minimal OAuth-style popup (open → child posts a
+   message back to `window.opener` → opener closes it) should round-trip.
+
+## Files to touch
+- `electron/ipc/webview.ts` — replace the Ticket-1 popup deny branch with the
+  `{ action: "allow", overrideBrowserWindowOptions }` path; capture and register
+  the child window; clean up on `webview:unregister`.
+- `electron/window.ts` — if a shared helper for creating/securing child windows or
+  hooking main-window-close cleanup fits better here, add it (reuse the existing
+  `webPreferences` and `setWindowOpenHandler` external-link policy at ~line 120).
+- (Optional) a small new module e.g. `electron/ipc/popups.ts` if the child-window
+  registry + lifecycle is cleaner extracted; otherwise keep it in `webview.ts`.

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-3-managed-child-window-popups.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-3-managed-child-window-popups.md
@@ -1,6 +1,6 @@
 ---
 title: Managed child window for communicating popups (OAuth/SSO/payment)
-status: in-progress
+status: done
 priority: high
 assignee: opus
 blocked_by: [1]

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-4-targeting-tests.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-4-targeting-tests.md
@@ -1,0 +1,40 @@
+---
+title: Tests for window/link targeting & popup routing
+status: todo
+priority: medium
+assignee: sonnet
+blocked_by: [1, 2, 3]
+---
+
+# Tests for window/link targeting & popup routing
+
+Cover the targeting matrix so the `_parent`/iframe regressions can't silently
+return and the popup routing stays correct.
+
+## Cases to cover
+
+1. **`_blank` link click → new manor tab** (foreground).
+2. **cmd/middle-click → background tab** (tab created, selection unchanged).
+3. **`window.open(url, '_parent')` / `'_self'` / `'_top'` → navigate in place**,
+   NOT a new tab (the bug #1 regression guard).
+4. **`window.open` from inside an `<iframe>` → handled** (bug #2 regression guard),
+   routed per its disposition.
+5. **`window.open(url, name, "width=…,height=…")` → managed child window**, with
+   the opener relationship intact (`opener` set, `postMessage` round-trips,
+   `closed` flips after `window.close()`).
+6. **Child window lifecycle**: closing the originating pane / main window cleans up
+   child windows (no orphans).
+
+## Approach
+
+Prefer the existing Playwright smoke suite (see ADR-128
+`adr-128-playwright-smoke-suite`) for the end-to-end webview cases; use unit tests
+for `addBrowserTab(url, { background })` selection behavior in the store. Match the
+project's existing test layout and runners — inspect how current webview/browser
+tests are structured before adding new ones, and follow that pattern.
+
+## Files to touch
+- Test files under the project's existing test directory (mirror current
+  Playwright / unit-test conventions — locate them first).
+- No production code changes; if a case is untestable without a small testability
+  hook, flag it rather than reworking Tickets 1–3.

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-4-targeting-tests.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-4-targeting-tests.md
@@ -1,6 +1,6 @@
 ---
 title: Tests for window/link targeting & popup routing
-status: in-progress
+status: done
 priority: medium
 assignee: sonnet
 blocked_by: [1, 2, 3]

--- a/docs/decisions/adr-145-webview-window-targeting/ticket-4-targeting-tests.md
+++ b/docs/decisions/adr-145-webview-window-targeting/ticket-4-targeting-tests.md
@@ -1,6 +1,6 @@
 ---
 title: Tests for window/link targeting & popup routing
-status: todo
+status: in-progress
 priority: medium
 assignee: sonnet
 blocked_by: [1, 2, 3]

--- a/electron/app-lifecycle.ts
+++ b/electron/app-lifecycle.ts
@@ -334,6 +334,15 @@ export function initApp(devTitle: string | null): void {
 
     mainWindow = createWindow();
 
+    // Backstop cleanup: child popup windows are parented to the main window so
+    // Chromium closes them with it, but explicitly flush the tracking registry
+    // on close so no entries or listeners leak.
+    if (mainWindow) {
+      mainWindow.on("close", () => {
+        webviewIpc.closeAllChildWindows();
+      });
+    }
+
     if (devTitle && mainWindow) {
       mainWindow.setTitle(devTitle);
       mainWindow.webContents.on("page-title-updated", (e) => {

--- a/electron/diff-watcher.ts
+++ b/electron/diff-watcher.ts
@@ -12,6 +12,9 @@ export class DiffWatcher {
   private lastStats: Record<string, DiffStats> = {};
   private scanning = false;
   private git: GitBackend;
+  // Paths discovered to not be git repos — skipped on subsequent ticks so we
+  // don't re-run git (and re-log) every interval. Reset on each start().
+  private nonGitPaths: Set<string> = new Set();
 
   constructor(git: GitBackend) {
     this.git = git;
@@ -21,6 +24,7 @@ export class DiffWatcher {
     this.stop();
     this.scanning = false;
     this.workspaces = new Map(Object.entries(workspaces));
+    this.nonGitPaths.clear();
 
     const tick = async () => {
       if (this.scanning) return;
@@ -81,6 +85,9 @@ export class DiffWatcher {
     wsPath: string,
     defaultBranch: string,
   ): Promise<DiffStats | null> {
+    // Skip paths already known to not be git repos (no rescan, no re-log).
+    if (this.nonGitPaths.has(wsPath)) return null;
+
     // Try origin/<branch> first (more reliable in worktrees), fall back to local ref
     const refs = [`origin/${defaultBranch}`, defaultBranch];
     for (const ref of refs) {
@@ -114,6 +121,12 @@ export class DiffWatcher {
         return { added, removed };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        // Directory isn't a git repo at all — ignore it completely and stop
+        // scanning it on future ticks.
+        if (msg.includes("not a git repository")) {
+          this.nonGitPaths.add(wsPath);
+          return null;
+        }
         // Silently skip refs that don't exist (e.g. local-only repo with no upstream)
         if (msg.includes("Not a valid object name")) {
           continue;

--- a/electron/ipc/__tests__/popups.test.ts
+++ b/electron/ipc/__tests__/popups.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+
+// popups.ts imports `BrowserWindow` and `shell` from electron at module scope.
+// We mock the whole electron module before importing the unit under test so the
+// pure helper `buildPopupWindowOptions` remains importable in the Node/vitest
+// environment without a running Electron instance.
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  shell: { openExternal: () => Promise.resolve() },
+}));
+
+import { vi } from "vitest";
+import { buildPopupWindowOptions } from "../popups";
+
+// ---------------------------------------------------------------------------
+// Constants mirrored from popups.ts (kept in sync manually)
+// ---------------------------------------------------------------------------
+const DEFAULT_POPUP_WIDTH = 600;
+const DEFAULT_POPUP_HEIGHT = 700;
+const MIN_POPUP_DIMENSION = 200;
+const MAX_POPUP_DIMENSION = 2000;
+
+// ---------------------------------------------------------------------------
+// Helper: extract width/height from the return value
+// ---------------------------------------------------------------------------
+function sizeOf(opts: ReturnType<typeof buildPopupWindowOptions>) {
+  return { width: opts.width, height: opts.height };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildPopupWindowOptions – features string parsing & size clamping", () => {
+  it("uses defaults when features string is empty", () => {
+    const opts = buildPopupWindowOptions(null, "");
+    expect(sizeOf(opts)).toEqual({
+      width: DEFAULT_POPUP_WIDTH,
+      height: DEFAULT_POPUP_HEIGHT,
+    });
+  });
+
+  it("uses defaults when features string has no width/height keys", () => {
+    const opts = buildPopupWindowOptions(null, "popup,scrollbars=yes");
+    expect(sizeOf(opts)).toEqual({
+      width: DEFAULT_POPUP_WIDTH,
+      height: DEFAULT_POPUP_HEIGHT,
+    });
+  });
+
+  it("parses explicit width and height from features string", () => {
+    const opts = buildPopupWindowOptions(null, "width=500,height=600");
+    expect(sizeOf(opts)).toEqual({ width: 500, height: 600 });
+  });
+
+  it("parses width/height with extra keys interspersed", () => {
+    const opts = buildPopupWindowOptions(null, "popup,width=800,scrollbars=yes,height=900");
+    expect(sizeOf(opts)).toEqual({ width: 800, height: 900 });
+  });
+
+  it("clamps width below MIN to MIN_POPUP_DIMENSION", () => {
+    const opts = buildPopupWindowOptions(null, "width=50,height=400");
+    expect(opts.width).toBe(MIN_POPUP_DIMENSION);
+    expect(opts.height).toBe(400);
+  });
+
+  it("clamps height below MIN to MIN_POPUP_DIMENSION", () => {
+    const opts = buildPopupWindowOptions(null, "width=400,height=1");
+    expect(opts.width).toBe(400);
+    expect(opts.height).toBe(MIN_POPUP_DIMENSION);
+  });
+
+  it("clamps width above MAX to MAX_POPUP_DIMENSION", () => {
+    const opts = buildPopupWindowOptions(null, "width=9999,height=400");
+    expect(opts.width).toBe(MAX_POPUP_DIMENSION);
+    expect(opts.height).toBe(400);
+  });
+
+  it("clamps height above MAX to MAX_POPUP_DIMENSION", () => {
+    const opts = buildPopupWindowOptions(null, "width=400,height=99999");
+    expect(opts.width).toBe(400);
+    expect(opts.height).toBe(MAX_POPUP_DIMENSION);
+  });
+
+  it("accepts a value exactly at MIN (no clamping)", () => {
+    const opts = buildPopupWindowOptions(null, `width=${MIN_POPUP_DIMENSION},height=${MIN_POPUP_DIMENSION}`);
+    expect(sizeOf(opts)).toEqual({
+      width: MIN_POPUP_DIMENSION,
+      height: MIN_POPUP_DIMENSION,
+    });
+  });
+
+  it("accepts a value exactly at MAX (no clamping)", () => {
+    const opts = buildPopupWindowOptions(null, `width=${MAX_POPUP_DIMENSION},height=${MAX_POPUP_DIMENSION}`);
+    expect(sizeOf(opts)).toEqual({
+      width: MAX_POPUP_DIMENSION,
+      height: MAX_POPUP_DIMENSION,
+    });
+  });
+
+  it("falls back to default width when width value is non-numeric", () => {
+    const opts = buildPopupWindowOptions(null, "width=abc,height=500");
+    expect(opts.width).toBe(DEFAULT_POPUP_WIDTH);
+    expect(opts.height).toBe(500);
+  });
+
+  it("falls back to default height when height value is non-numeric", () => {
+    const opts = buildPopupWindowOptions(null, "width=500,height=xyz");
+    expect(opts.width).toBe(500);
+    expect(opts.height).toBe(DEFAULT_POPUP_HEIGHT);
+  });
+
+  it("falls back to defaults when width is zero", () => {
+    const opts = buildPopupWindowOptions(null, "width=0,height=0");
+    expect(sizeOf(opts)).toEqual({
+      width: DEFAULT_POPUP_WIDTH,
+      height: DEFAULT_POPUP_HEIGHT,
+    });
+  });
+
+  it("falls back to defaults when width is negative", () => {
+    const opts = buildPopupWindowOptions(null, "width=-100,height=-200");
+    expect(sizeOf(opts)).toEqual({
+      width: DEFAULT_POPUP_WIDTH,
+      height: DEFAULT_POPUP_HEIGHT,
+    });
+  });
+
+  it("rounds fractional pixel values", () => {
+    // parseFeaturesSize uses parseInt so 499.9 → 499, which is in range
+    const opts = buildPopupWindowOptions(null, "width=499,height=499");
+    expect(opts.width).toBe(499);
+    expect(opts.height).toBe(499);
+  });
+
+  it("sets secure webPreferences regardless of features", () => {
+    const opts = buildPopupWindowOptions(null, "width=500,height=600");
+    expect(opts.webPreferences).toMatchObject({
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    });
+  });
+
+  it("sets minWidth and minHeight to MIN_POPUP_DIMENSION", () => {
+    const opts = buildPopupWindowOptions(null, "");
+    expect(opts.minWidth).toBe(MIN_POPUP_DIMENSION);
+    expect(opts.minHeight).toBe(MIN_POPUP_DIMENSION);
+  });
+
+  it("accepts a non-null mainWindow and sets it as parent", () => {
+    // We just need any object to stand in for a BrowserWindow reference;
+    // buildPopupWindowOptions assigns it to `parent` without calling methods.
+    const fakeWindow = { id: 1 } as unknown as Electron.BrowserWindow;
+    const opts = buildPopupWindowOptions(fakeWindow, "width=400,height=500");
+    expect(opts.parent).toBe(fakeWindow);
+  });
+
+  it("sets parent to undefined when mainWindow is null", () => {
+    const opts = buildPopupWindowOptions(null, "width=400,height=500");
+    expect(opts.parent).toBeUndefined();
+  });
+
+  it("is tolerant of extra whitespace around key/value pairs", () => {
+    const opts = buildPopupWindowOptions(null, " width = 500 , height = 600 ");
+    expect(sizeOf(opts)).toEqual({ width: 500, height: 600 });
+  });
+
+  it("treats keys case-insensitively (WIDTH/HEIGHT)", () => {
+    // parseFeaturesSize lowercases keys, so WIDTH and HEIGHT should parse
+    const opts = buildPopupWindowOptions(null, "WIDTH=500,HEIGHT=600");
+    expect(sizeOf(opts)).toEqual({ width: 500, height: 600 });
+  });
+});

--- a/electron/ipc/popups.ts
+++ b/electron/ipc/popups.ts
@@ -1,0 +1,147 @@
+import { BrowserWindow, shell } from "electron";
+
+// Default size for a communicating popup when the guest does not request one
+// (or requests something unreasonable). OAuth/SSO consent screens are usually
+// portrait-ish and modest in size.
+const DEFAULT_POPUP_WIDTH = 600;
+const DEFAULT_POPUP_HEIGHT = 700;
+// Clamp requested sizes so a guest can't open a 1px or a screen-swallowing
+// window. These are best-effort, per the ADR ("manor may normalize them").
+const MIN_POPUP_DIMENSION = 200;
+const MAX_POPUP_DIMENSION = 2000;
+
+// Child windows opened from a guest <webview>, keyed by the originating paneId.
+// A single pane can spawn more than one popup (e.g. re-opening a closed OAuth
+// window), so each pane maps to a set of live child windows.
+const childWindowsByPane = new Map<string, Set<BrowserWindow>>();
+
+function clampDimension(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.max(Math.round(value), MIN_POPUP_DIMENSION), MAX_POPUP_DIMENSION);
+}
+
+/**
+ * Build the `overrideBrowserWindowOptions` for a communicating popup child
+ * window. Parented to the main window so it closes with it, sized from the
+ * guest's requested `features` (clamped/normalized), and locked to secure
+ * webPreferences matching the main window (contextIsolation on, nodeIntegration
+ * off, sandbox on). `width`/`height` are parsed by Electron from the `features`
+ * string into the merged options it passes to `did-create-window`; we normalize
+ * them here and let our explicit options take precedence.
+ */
+export function buildPopupWindowOptions(
+  mainWindow: BrowserWindow | null,
+  features: string,
+): Electron.BrowserWindowConstructorOptions {
+  const { width, height } = parseFeaturesSize(features);
+  return {
+    parent: mainWindow ?? undefined,
+    width: clampDimension(width, DEFAULT_POPUP_WIDTH),
+    height: clampDimension(height, DEFAULT_POPUP_HEIGHT),
+    minWidth: MIN_POPUP_DIMENSION,
+    minHeight: MIN_POPUP_DIMENSION,
+    backgroundColor: "#1e1e2e",
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  };
+}
+
+/**
+ * Parse `width`/`height` out of a `window.open` features string
+ * (e.g. "width=500,height=600,popup"). Missing/invalid values come back
+ * undefined and fall through to defaults.
+ */
+function parseFeaturesSize(features: string): {
+  width?: number;
+  height?: number;
+} {
+  const result: { width?: number; height?: number } = {};
+  for (const part of features.split(",")) {
+    const [rawKey, rawValue] = part.split("=");
+    const key = rawKey?.trim().toLowerCase();
+    if (!rawValue) continue;
+    const value = Number.parseInt(rawValue.trim(), 10);
+    if (Number.isNaN(value)) continue;
+    if (key === "width") result.width = value;
+    else if (key === "height") result.height = value;
+  }
+  return result;
+}
+
+/**
+ * Register a freshly created child popup window against its originating pane.
+ * Applies the same external-link policy as the main window so the popup can't
+ * spawn an unbounded chain of further popups (http/https opens go to the system
+ * browser), and removes the window from the registry on `closed`.
+ */
+export function registerChildWindow(
+  paneId: string,
+  childWindow: BrowserWindow,
+): void {
+  let set = childWindowsByPane.get(paneId);
+  if (!set) {
+    set = new Set<BrowserWindow>();
+    childWindowsByPane.set(paneId, set);
+  }
+  set.add(childWindow);
+
+  // Further window.open from inside the popup goes to the system browser
+  // rather than spawning nested popups (mirror electron/window.ts policy).
+  childWindow.webContents.setWindowOpenHandler(({ url }) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        shell.openExternal(url);
+      }
+    } catch {
+      /* ignore malformed URLs */
+    }
+    return { action: "deny" };
+  });
+
+  childWindow.on("closed", () => {
+    const current = childWindowsByPane.get(paneId);
+    if (!current) return;
+    current.delete(childWindow);
+    if (current.size === 0) {
+      childWindowsByPane.delete(paneId);
+    }
+  });
+}
+
+/**
+ * Close and forget every child popup window opened from the given pane. Called
+ * when the pane is unregistered (its <webview> goes away) so popups don't
+ * outlive their opener.
+ */
+export function closeChildWindowsForPane(paneId: string): void {
+  const set = childWindowsByPane.get(paneId);
+  if (!set) return;
+  // Copy first: close() triggers the `closed` handler which mutates the set.
+  for (const win of [...set]) {
+    if (!win.isDestroyed()) {
+      win.destroy();
+    }
+  }
+  childWindowsByPane.delete(paneId);
+}
+
+/**
+ * Close and forget all tracked child popup windows across every pane. Called
+ * when the main window is closing as a defensive backstop (children are
+ * parented to the main window so Chromium closes them too, but this guarantees
+ * the registry is emptied and no listeners leak).
+ */
+export function closeAllChildWindows(): void {
+  for (const paneId of [...childWindowsByPane.keys()]) {
+    closeChildWindowsForPane(paneId);
+  }
+}

--- a/electron/ipc/webview.ts
+++ b/electron/ipc/webview.ts
@@ -12,6 +12,16 @@ import { assertString } from "../ipc-validate";
 import { PICKER_SCRIPT } from "../picker-script";
 import { WebviewServer } from "../webview-server";
 import type { IpcDeps } from "./types";
+import {
+  buildPopupWindowOptions,
+  closeAllChildWindows,
+  closeChildWindowsForPane,
+  registerChildWindow,
+} from "./popups";
+
+// Re-exported so callers (e.g. main-window lifecycle) can flush all tracked
+// child popup windows without importing the popups module directly.
+export { closeAllChildWindows };
 
 export const webviewRegistry = new Map<string, number>();
 
@@ -20,6 +30,7 @@ const webviewEscapeCleanup = new Map<string, () => void>();
 const webviewUnloadCleanup = new Map<string, () => void>();
 const webviewEventCleanup = new Map<string, () => void>();
 const webviewAudioCleanup = new Map<string, () => void>();
+const webviewPopupCleanup = new Map<string, () => void>();
 
 export function createWebviewServer(): WebviewServer {
   return new WebviewServer(webviewRegistry);
@@ -227,8 +238,9 @@ export function register(deps: IpcDeps): void {
         //
         // Navigation-style opens (foreground-tab / background-tab) become manor
         // tabs. Communicating popups (new-window disposition and/or non-empty
-        // features) are denied for now — Ticket 3 replaces that branch with a
-        // managed child BrowserWindow that preserves the opener relationship.
+        // features) are allowed through as a real, managed child BrowserWindow
+        // so the Chromium opener relationship (window.opener, postMessage,
+        // closed, close(), named reuse) is preserved end-to-end.
         wc.setWindowOpenHandler(({ url, disposition, features }) => {
           if (disposition === "foreground-tab" || disposition === "background-tab") {
             rendererWebContents.send("webview:new-window", paneId, url, {
@@ -238,12 +250,29 @@ export function register(deps: IpcDeps): void {
           }
 
           // Communicating popup (OAuth/SSO/payment): disposition "new-window"
-          // and/or window features requesting a sized popup. Denied for now.
-          // TODO(ticket-3): replace with a managed child BrowserWindow
-          // (overrideBrowserWindowOptions + did-create-window tracking) so
-          // window.opener, postMessage, closed, close(), and named reuse work.
-          void features;
-          return { action: "deny" };
+          // and/or window features requesting a sized popup. Allow Chromium to
+          // create a child window (parented to the main window, secure
+          // webPreferences, normalized size). The child is captured in
+          // `did-create-window` below and tracked for cleanup.
+          return {
+            action: "allow",
+            overrideBrowserWindowOptions: buildPopupWindowOptions(
+              getMainWindow(),
+              features,
+            ),
+          };
+        });
+
+        // Capture the child window created by the allow branch above so it can
+        // be tracked, given its own external-link policy, and cleaned up when
+        // the pane is unregistered or the main window closes.
+        const didCreateWindowHandler = (childWindow: Electron.BrowserWindow) => {
+          registerChildWindow(paneId, childWindow);
+        };
+        wc.on("did-create-window", didCreateWindowHandler);
+        webviewPopupCleanup.set(paneId, () => {
+          wc.off("did-create-window", didCreateWindowHandler);
+          closeChildWindowsForPane(paneId);
         });
 
         // Handle beforeunload — show a native confirm dialog when the page
@@ -283,6 +312,8 @@ export function register(deps: IpcDeps): void {
     webviewEventCleanup.delete(paneId);
     webviewAudioCleanup.get(paneId)?.();
     webviewAudioCleanup.delete(paneId);
+    webviewPopupCleanup.get(paneId)?.();
+    webviewPopupCleanup.delete(paneId);
     deps.webviewServer.detachConsoleListener(paneId);
     webviewRegistry.delete(paneId);
   });

--- a/electron/ipc/webview.ts
+++ b/electron/ipc/webview.ts
@@ -17,30 +17,9 @@ export const webviewRegistry = new Map<string, number>();
 
 const webviewContextMenuCleanup = new Map<string, () => void>();
 const webviewEscapeCleanup = new Map<string, () => void>();
-const newWindowConsoleCleanup = new Map<string, () => void>();
+const webviewUnloadCleanup = new Map<string, () => void>();
 const webviewEventCleanup = new Map<string, () => void>();
 const webviewAudioCleanup = new Map<string, () => void>();
-
-const INTERCEPT_NEW_WINDOW_SCRIPT = `
-(function() {
-  if (window.__manor_intercept_new_window__) return;
-  window.__manor_intercept_new_window__ = true;
-  document.addEventListener('click', function(e) {
-    var el = e.target;
-    while (el && el.tagName !== 'A') el = el.parentElement;
-    if (!el) return;
-    if (el.getAttribute('target') === '_blank' && el.href) {
-      e.preventDefault();
-      e.stopPropagation();
-      console.log('__manor_new_window__:' + el.href);
-    }
-  }, true);
-  window.open = function(url) {
-    if (url) console.log('__manor_new_window__:' + url);
-    return null;
-  };
-})();
-`;
 
 export function createWebviewServer(): WebviewServer {
   return new WebviewServer(webviewRegistry);
@@ -227,24 +206,45 @@ export function register(deps: IpcDeps): void {
           wc.off("audio-state-changed", audioPlayingHandler as any);
         });
 
-        // Intercept target="_blank" clicks and window.open() inside the guest page.
-        const injectNewWindowIntercept = () => {
-          if (wc.isDestroyed()) return;
-          wc.executeJavaScript(INTERCEPT_NEW_WINDOW_SCRIPT).catch(() => {});
-        };
-        wc.on("did-finish-load", injectNewWindowIntercept);
-
-        const newWindowListener = (
-          _ev: Electron.Event,
-          _level: number,
-          message: string,
-        ) => {
-          if (message.startsWith("__manor_new_window__:")) {
-            const url = message.slice("__manor_new_window__:".length);
-            rendererWebContents.send("webview:new-window", paneId, url);
+        // New-window handling via Electron's native open path. This requires the
+        // <webview> to carry the `allowpopups` attribute (see BrowserPane.tsx);
+        // without it the guest's window.open is blocked before this handler runs.
+        //
+        // Routing is by intent, keyed on `disposition` / `features`:
+        //
+        //   Observed disposition mapping (Electron 35, from docs — NOT yet
+        //   verified empirically in-app; orchestrator/verifier should confirm
+        //   via the Ticket 1 spike):
+        //   - <a target="_blank"> click          -> "foreground-tab"
+        //   - cmd/ctrl+click, middle-click        -> "background-tab"
+        //   - window.open(url)  (no features)     -> "foreground-tab"
+        //   - window.open(url, name, "width=…")   -> "new-window" / features set
+        //   - window.open(url, "_self"|"_parent"|"_top")
+        //         -> does NOT reach this handler; surfaces as will-navigate on
+        //            the guest and navigates in place (bug #1 fix).
+        //   - window.open from inside an <iframe>  -> reaches this handler now
+        //         that allowpopups is set (bug #2 fix).
+        //
+        // Navigation-style opens (foreground-tab / background-tab) become manor
+        // tabs. Communicating popups (new-window disposition and/or non-empty
+        // features) are denied for now — Ticket 3 replaces that branch with a
+        // managed child BrowserWindow that preserves the opener relationship.
+        wc.setWindowOpenHandler(({ url, disposition, features }) => {
+          if (disposition === "foreground-tab" || disposition === "background-tab") {
+            rendererWebContents.send("webview:new-window", paneId, url, {
+              background: disposition === "background-tab",
+            });
+            return { action: "deny" };
           }
-        };
-        wc.on("console-message", newWindowListener);
+
+          // Communicating popup (OAuth/SSO/payment): disposition "new-window"
+          // and/or window features requesting a sized popup. Denied for now.
+          // TODO(ticket-3): replace with a managed child BrowserWindow
+          // (overrideBrowserWindowOptions + did-create-window tracking) so
+          // window.opener, postMessage, closed, close(), and named reuse work.
+          void features;
+          return { action: "deny" };
+        });
 
         // Handle beforeunload — show a native confirm dialog when the page
         // tries to prevent navigation (e.g. unsaved changes warnings).
@@ -264,9 +264,7 @@ export function register(deps: IpcDeps): void {
         };
         wc.on("will-prevent-unload", preventUnloadHandler);
 
-        newWindowConsoleCleanup.set(paneId, () => {
-          wc.off("did-finish-load", injectNewWindowIntercept);
-          wc.off("console-message", newWindowListener);
+        webviewUnloadCleanup.set(paneId, () => {
           wc.off("will-prevent-unload", preventUnloadHandler);
         });
       }
@@ -279,8 +277,8 @@ export function register(deps: IpcDeps): void {
     webviewContextMenuCleanup.delete(paneId);
     webviewEscapeCleanup.get(paneId)?.();
     webviewEscapeCleanup.delete(paneId);
-    newWindowConsoleCleanup.get(paneId)?.();
-    newWindowConsoleCleanup.delete(paneId);
+    webviewUnloadCleanup.get(paneId)?.();
+    webviewUnloadCleanup.delete(paneId);
     webviewEventCleanup.get(paneId)?.();
     webviewEventCleanup.delete(paneId);
     webviewAudioCleanup.get(paneId)?.();

--- a/electron/ipc/webview.ts
+++ b/electron/ipc/webview.ts
@@ -5,8 +5,6 @@ import {
   dialog,
   BrowserWindow,
   clipboard,
-  nativeImage,
-  shell,
 } from "electron";
 import { assertString } from "../ipc-validate";
 import { PICKER_SCRIPT } from "../picker-script";

--- a/electron/mcp-webview-server.ts
+++ b/electron/mcp-webview-server.ts
@@ -20,39 +20,57 @@ import { webviewServerPortFile } from "./paths";
 
 const PORT_FILE = webviewServerPortFile();
 
-function readPort(): number {
-  const envPort = process.env.MANOR_WEBVIEW_PORT;
-  if (envPort) {
-    const p = parseInt(envPort, 10);
-    if (!isNaN(p) && p > 0) return p;
+// Candidate ports to reach Manor's webview server, in priority order:
+//   1. MANOR_WEBVIEW_PORT env — set by the host Manor instance (correct target
+//      in multi-instance setups), but goes stale if that instance restarts.
+//   2. The ~/.manor/webview-server-port file — always rewritten by the running
+//      instance, so it self-heals after a restart.
+// Resolved per request (not cached at startup) so restarts don't wedge us.
+function candidatePorts(): number[] {
+  const ports: number[] = [];
+  const envPort = parseInt(process.env.MANOR_WEBVIEW_PORT ?? "", 10);
+  if (!isNaN(envPort) && envPort > 0) ports.push(envPort);
+  if (fs.existsSync(PORT_FILE)) {
+    const filePort = parseInt(fs.readFileSync(PORT_FILE, "utf-8").trim(), 10);
+    if (!isNaN(filePort) && filePort > 0 && !ports.includes(filePort)) {
+      ports.push(filePort);
+    }
   }
-  if (!fs.existsSync(PORT_FILE)) {
+  if (ports.length === 0) {
     throw new Error(
-      `Port file not found at ${PORT_FILE} — is Manor running?`,
+      `No Manor webview port found (env MANOR_WEBVIEW_PORT or ${PORT_FILE}) — is Manor running?`,
     );
   }
-  const port = parseInt(fs.readFileSync(PORT_FILE, "utf-8").trim(), 10);
-  if (isNaN(port)) {
-    throw new Error(`Invalid port in ${PORT_FILE}`);
-  }
-  return port;
+  return ports;
 }
 
-// Resolve the base URL per request rather than once at startup, so the server
-// survives Manor restarts (which rewrite the port file with a new port).
-function baseUrl(): string {
-  return `http://127.0.0.1:${readPort()}`;
+// Try each candidate port until one answers. Connection-level failures fall
+// through to the next candidate; an HTTP error from a live server is surfaced
+// as-is (don't mask a real error by retrying a different instance).
+async function request(urlPath: string, init?: RequestInit): Promise<unknown> {
+  let lastErr: unknown;
+  for (const port of candidatePorts()) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}${urlPath}`, init);
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`HTTP ${res.status}: ${body}`);
+      }
+      return await res.json();
+    } catch (err) {
+      lastErr = err;
+      const isConnError =
+        err instanceof TypeError && (err as NodeJS.ErrnoException).cause;
+      if (!isConnError) throw err;
+    }
+  }
+  throw lastErr;
 }
 
 // ── HTTP helpers ──
 
 async function httpGet(urlPath: string): Promise<unknown> {
-  const res = await fetch(`${baseUrl()}${urlPath}`);
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`HTTP ${res.status}: ${body}`);
-  }
-  return res.json();
+  return request(urlPath);
 }
 
 async function httpPost(
@@ -68,12 +86,7 @@ async function httpPost(
   if (timeoutMs !== undefined) {
     init.signal = AbortSignal.timeout(timeoutMs);
   }
-  const res = await fetch(`${baseUrl()}${urlPath}`, init);
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`HTTP ${res.status}: ${text}`);
-  }
-  return res.json();
+  return request(urlPath, init);
 }
 
 // ── Pane resolution ──

--- a/electron/mcp-webview-server.ts
+++ b/electron/mcp-webview-server.ts
@@ -27,25 +27,27 @@ function readPort(): number {
     if (!isNaN(p) && p > 0) return p;
   }
   if (!fs.existsSync(PORT_FILE)) {
-    console.error(
-      `[mcp-webview] Port file not found at ${PORT_FILE} — is Manor running?`,
+    throw new Error(
+      `Port file not found at ${PORT_FILE} — is Manor running?`,
     );
-    process.exit(1);
   }
   const port = parseInt(fs.readFileSync(PORT_FILE, "utf-8").trim(), 10);
   if (isNaN(port)) {
-    console.error(`[mcp-webview] Invalid port in ${PORT_FILE}`);
-    process.exit(1);
+    throw new Error(`Invalid port in ${PORT_FILE}`);
   }
   return port;
 }
 
-const BASE_URL = `http://127.0.0.1:${readPort()}`;
+// Resolve the base URL per request rather than once at startup, so the server
+// survives Manor restarts (which rewrite the port file with a new port).
+function baseUrl(): string {
+  return `http://127.0.0.1:${readPort()}`;
+}
 
 // ── HTTP helpers ──
 
 async function httpGet(urlPath: string): Promise<unknown> {
-  const res = await fetch(`${BASE_URL}${urlPath}`);
+  const res = await fetch(`${baseUrl()}${urlPath}`);
   if (!res.ok) {
     const body = await res.text();
     throw new Error(`HTTP ${res.status}: ${body}`);
@@ -66,7 +68,7 @@ async function httpPost(
   if (timeoutMs !== undefined) {
     init.signal = AbortSignal.timeout(timeoutMs);
   }
-  const res = await fetch(`${BASE_URL}${urlPath}`, init);
+  const res = await fetch(`${baseUrl()}${urlPath}`, init);
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`HTTP ${res.status}: ${text}`);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -451,12 +451,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
       onChannel('webview:escape', callback),
     onFocusUrl: (callback: (paneId: string) => void) =>
       onChannel('webview:focus-url', callback),
-    onNewWindow: (callback: (paneId: string, url: string) => void) => {
+    onNewWindow: (
+      callback: (paneId: string, url: string, opts?: { background?: boolean }) => void,
+    ) => {
       const listener = (
         _event: Electron.IpcRendererEvent,
         paneId: string,
         url: string,
-      ) => callback(paneId, url);
+        opts?: { background?: boolean },
+      ) => callback(paneId, url, opts);
       ipcRenderer.on("webview:new-window", listener);
       return () =>
         ipcRenderer.removeListener("webview:new-window", listener);

--- a/src/components/command-palette/useCommands.tsx
+++ b/src/components/command-palette/useCommands.tsx
@@ -26,7 +26,7 @@ import styles from "./CommandPalette.module.css";
 
 interface UseCommandsParams {
   addTab: () => void;
-  addBrowserTab: (url: string) => void;
+  addBrowserTab: (url: string, opts?: { background?: boolean }) => void;
   closePane: () => void;
   closeTab: (tabId: string) => void;
   splitPane: (direction: "horizontal" | "vertical") => void;

--- a/src/components/workspace-panes/BrowserPane/BrowserPane.tsx
+++ b/src/components/workspace-panes/BrowserPane/BrowserPane.tsx
@@ -111,6 +111,14 @@ function formatPickedElement(result: PickedElementResult): string {
   return sections.join("\n\n");
 }
 
+// React 19 silently drops a boolean `allowpopups={true}` on <webview>, leaving
+// the attribute absent — which makes Electron block all guest window.open /
+// target=_blank before they reach setWindowOpenHandler. Emit it as a string
+// attribute instead (Electron only checks for presence). Spread to bypass the
+// boolean prop type in React's WebViewHTMLAttributes.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const WEBVIEW_ALLOW_POPUPS: any = { allowpopups: "true" };
+
 export const BrowserPane = forwardRef<BrowserPaneRef, BrowserPaneProps>(
   function BrowserPane(props: BrowserPaneProps, ref) {
     const { paneId, initialUrl, onNavStateChange } = props;
@@ -526,10 +534,11 @@ export const BrowserPane = forwardRef<BrowserPaneRef, BrowserPaneProps>(
           <webview
             ref={webviewRef as React.RefObject<HTMLElement>}
             src={initialUrl}
-            // allowpopups lets guest window.open requests reach the native
-            // setWindowOpenHandler in electron/ipc/webview.ts (the sole open
-            // authority); without it they are blocked before the handler runs.
-            allowpopups={true}
+            // allowpopups (string attr — see WEBVIEW_ALLOW_POPUPS) lets guest
+            // window.open / target=_blank reach the native setWindowOpenHandler
+            // in electron/ipc/webview.ts; without it the open is blocked before
+            // the handler ever runs.
+            {...WEBVIEW_ALLOW_POPUPS}
           />
           {isBlank && (
             <div className={styles.emptyState}>Enter a URL to get started</div>

--- a/src/components/workspace-panes/BrowserPane/BrowserPane.tsx
+++ b/src/components/workspace-panes/BrowserPane/BrowserPane.tsx
@@ -175,7 +175,9 @@ export const BrowserPane = forwardRef<BrowserPaneRef, BrowserPaneProps>(
       const wv = webviewRef.current;
       if (!wv) return;
       let resolved = target.trim();
-      if (!/^https?:\/\//i.test(resolved)) {
+      // Pass through explicit URL schemes (http(s), file, data, about, …) as
+      // typed; only bare hosts / search terms get normalized below.
+      if (!/^(https?|file|data|about|blob|chrome|view-source):/i.test(resolved)) {
         const isLocal = /^(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/i.test(resolved);
         if (isLocal) {
           resolved = `http://${resolved}`;
@@ -183,7 +185,7 @@ export const BrowserPane = forwardRef<BrowserPaneRef, BrowserPaneProps>(
           // Has dots — treat as a domain (e.g. "github.com", "foo.bar.com/path")
           resolved = `https://${resolved}`;
         } else {
-          // No dots, no protocol, not localhost — treat as a search query
+          // No dots, no scheme, not localhost — treat as a search query
           resolved = `https://www.google.com/search?q=${encodeURIComponent(resolved)}`;
         }
       }

--- a/src/components/workspace-panes/BrowserPane/BrowserPane.tsx
+++ b/src/components/workspace-panes/BrowserPane/BrowserPane.tsx
@@ -436,9 +436,9 @@ export const BrowserPane = forwardRef<BrowserPaneRef, BrowserPaneProps>(
       );
 
       const unsubNewWindow = window.electronAPI.webview.onNewWindow(
-        (sourcePaneId: string, openUrl: string) => {
+        (sourcePaneId: string, openUrl: string, opts?: { background?: boolean }) => {
           if (sourcePaneId !== paneId) return;
-          useAppStore.getState().addBrowserTab(openUrl);
+          useAppStore.getState().addBrowserTab(openUrl, { background: opts?.background });
         },
       );
 

--- a/src/components/workspace-panes/BrowserPane/BrowserPane.tsx
+++ b/src/components/workspace-panes/BrowserPane/BrowserPane.tsx
@@ -524,6 +524,10 @@ export const BrowserPane = forwardRef<BrowserPaneRef, BrowserPaneProps>(
           <webview
             ref={webviewRef as React.RefObject<HTMLElement>}
             src={initialUrl}
+            // allowpopups lets guest window.open requests reach the native
+            // setWindowOpenHandler in electron/ipc/webview.ts (the sole open
+            // authority); without it they are blocked before the handler runs.
+            allowpopups={true}
           />
           {isBlank && (
             <div className={styles.emptyState}>Enter a URL to get started</div>

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -605,7 +605,7 @@ export interface ElectronAPI {
     onEscape: (callback: (paneId: string) => void) => () => void;
     onFocusUrl: (callback: (paneId: string) => void) => () => void;
     onNewWindow: (
-      callback: (paneId: string, url: string) => void,
+      callback: (paneId: string, url: string, opts?: { background?: boolean }) => void,
     ) => () => void;
     stop: (paneId: string) => Promise<void>;
     findInPage: (paneId: string, query: string, options?: { forward?: boolean; findNext?: boolean }) => Promise<void>;

--- a/src/store/__tests__/app-store-add-browser-tab.test.ts
+++ b/src/store/__tests__/app-store-add-browser-tab.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "../app-store";
+import type { Panel, WorkspaceLayout } from "../app-store";
+
+// window is provided by the setup file (src/store/__tests__/setup.ts)
+// with a minimal electronAPI mock. No additional stubbing needed here.
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WS_PATH = "/test/workspace";
+
+function makeLayout(): WorkspaceLayout {
+  const panelId = "panel-1";
+  const paneId = "pane-1";
+  const tab = {
+    id: "tab-1",
+    title: "Terminal",
+    rootNode: { type: "leaf" as const, paneId },
+    focusedPaneId: paneId,
+  };
+  const panel: Panel = {
+    id: panelId,
+    tabs: [tab],
+    selectedTabId: "tab-1",
+    pinnedTabIds: [],
+  };
+  return {
+    panelTree: { type: "leaf", panelId },
+    panels: { [panelId]: panel },
+    activePanelId: panelId,
+  };
+}
+
+function setupStore(layout?: WorkspaceLayout) {
+  useAppStore.setState({
+    activeWorkspacePath: WS_PATH,
+    workspaceLayouts: { [WS_PATH]: layout ?? makeLayout() },
+    paneCwd: {},
+    paneTitle: {},
+    paneAgentStatus: {},
+    paneContentType: {},
+    paneUrl: {},
+    panePickedElement: {},
+    closedPaneIds: new Set(),
+    closedPaneStack: [],
+    pendingStartupCommands: {},
+    pendingPaneCommands: {},
+    pendingCloseConfirmPaneId: null,
+    pendingCloseConfirmTabId: null,
+    webviewFocusedPaneId: null,
+  });
+}
+
+function getActivePanel(): Panel {
+  const state = useAppStore.getState();
+  const layout = state.workspaceLayouts[WS_PATH];
+  return layout.panels[layout.activePanelId];
+}
+
+// ---------------------------------------------------------------------------
+// Tests: addBrowserTab background option
+// ---------------------------------------------------------------------------
+
+describe("addBrowserTab", () => {
+  beforeEach(() => setupStore());
+
+  it("creates a new browser tab in the active panel (foreground by default)", () => {
+    const panelBefore = getActivePanel();
+    const originalSelectedTabId = panelBefore.selectedTabId;
+    expect(panelBefore.tabs).toHaveLength(1);
+
+    useAppStore.getState().addBrowserTab("https://example.com");
+
+    const panel = getActivePanel();
+    expect(panel.tabs).toHaveLength(2);
+
+    const newTab = panel.tabs[1];
+    expect(newTab.rootNode.type).toBe("leaf");
+    // The new tab becomes selected (foreground)
+    expect(panel.selectedTabId).toBe(newTab.id);
+    expect(panel.selectedTabId).not.toBe(originalSelectedTabId);
+  });
+
+  it("creates a browser tab WITHOUT changing selection when background: true", () => {
+    const panelBefore = getActivePanel();
+    const originalSelectedTabId = panelBefore.selectedTabId;
+    expect(panelBefore.tabs).toHaveLength(1);
+
+    useAppStore.getState().addBrowserTab("https://example.com", { background: true });
+
+    const panel = getActivePanel();
+    expect(panel.tabs).toHaveLength(2);
+
+    // Selection must remain on the original tab
+    expect(panel.selectedTabId).toBe(originalSelectedTabId);
+
+    // The new tab is appended but not selected
+    const newTab = panel.tabs[1];
+    expect(newTab.id).not.toBe(originalSelectedTabId);
+  });
+
+  it("creates a browser tab AND selects it when background: false (explicit)", () => {
+    const panelBefore = getActivePanel();
+    const originalSelectedTabId = panelBefore.selectedTabId;
+    expect(panelBefore.tabs).toHaveLength(1);
+
+    useAppStore.getState().addBrowserTab("https://example.com", { background: false });
+
+    const panel = getActivePanel();
+    expect(panel.tabs).toHaveLength(2);
+
+    const newTab = panel.tabs[1];
+    // Selection moves to the new tab
+    expect(panel.selectedTabId).toBe(newTab.id);
+    expect(panel.selectedTabId).not.toBe(originalSelectedTabId);
+  });
+
+  it("sets paneContentType to 'browser' for the new pane", () => {
+    useAppStore.getState().addBrowserTab("https://example.com");
+
+    const panel = getActivePanel();
+    const newTab = panel.tabs[1];
+    if (newTab.rootNode.type !== "leaf") throw new Error("Expected leaf");
+    const paneId = newTab.rootNode.paneId;
+
+    expect(useAppStore.getState().paneContentType[paneId]).toBe("browser");
+  });
+
+  it("sets paneUrl for the new pane", () => {
+    useAppStore.getState().addBrowserTab("https://example.com/path");
+
+    const panel = getActivePanel();
+    const newTab = panel.tabs[1];
+    if (newTab.rootNode.type !== "leaf") throw new Error("Expected leaf");
+    const paneId = newTab.rootNode.paneId;
+
+    expect(useAppStore.getState().paneUrl[paneId]).toBe("https://example.com/path");
+  });
+
+  it("uses the URL host as the tab title", () => {
+    useAppStore.getState().addBrowserTab("https://example.com/some/path");
+
+    const panel = getActivePanel();
+    const newTab = panel.tabs[1];
+    expect(newTab.title).toBe("example.com");
+  });
+
+  it("falls back to the full URL as title when URL is not parseable", () => {
+    const invalidUrl = "not-a-url";
+    useAppStore.getState().addBrowserTab(invalidUrl);
+
+    const panel = getActivePanel();
+    const newTab = panel.tabs[1];
+    expect(newTab.title).toBe(invalidUrl);
+  });
+
+  it("background: true does not change selection even when multiple tabs exist", () => {
+    // Add a foreground tab first so we start with 2 tabs
+    useAppStore.getState().addBrowserTab("https://first.com");
+    const panelMid = getActivePanel();
+    const selectedAfterFirst = panelMid.selectedTabId;
+    expect(panelMid.tabs).toHaveLength(2);
+
+    // Now add a background tab — selection must remain on the second tab
+    useAppStore.getState().addBrowserTab("https://second.com", { background: true });
+
+    const panel = getActivePanel();
+    expect(panel.tabs).toHaveLength(3);
+    expect(panel.selectedTabId).toBe(selectedAfterFirst);
+  });
+});

--- a/src/store/__tests__/setup.ts
+++ b/src/store/__tests__/setup.ts
@@ -16,6 +16,25 @@ if (typeof globalThis.window === "undefined") {
         load: vi.fn().mockResolvedValue(null),
         save: vi.fn(),
       },
+      // task-store.ts subscribes to tasks.onUpdate at module-init time, and
+      // app-store.closePaneById calls tasks.abandonForPane. Provide a minimal
+      // tasks surface so importing those stores does not throw. Individual
+      // tests can override specific methods via vi.stubGlobal.
+      tasks: {
+        onUpdate: vi.fn(() => vi.fn()),
+        markSeen: vi.fn().mockResolvedValue(undefined),
+        abandonForPane: vi.fn().mockResolvedValue(undefined),
+        consumePruneNotice: vi.fn().mockResolvedValue(null),
+        delete: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn().mockResolvedValue(null),
+        getActive: vi.fn().mockResolvedValue([]),
+        getAll: vi.fn().mockResolvedValue([]),
+        getUnseen: vi.fn().mockResolvedValue([]),
+      },
+      // task-store.ts also subscribes to notifications.onNavigateToTask at init.
+      notifications: {
+        onNavigateToTask: vi.fn(() => vi.fn()),
+      },
     },
   };
   (globalThis as unknown as Record<string, unknown>).window = win;

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -232,7 +232,7 @@ export interface AppState {
   // Tab operations
   addTab: (paneId?: string) => void;
   addTerminalTab: (command: string, paneId?: string) => void;
-  addBrowserTab: (url: string) => void;
+  addBrowserTab: (url: string, opts?: { background?: boolean }) => void;
   addDiffTab: () => void;
   duplicateTab: (tabId: string) => void;
   openOrFocusDiff: () => void;
@@ -644,7 +644,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       };
     }),
 
-  addBrowserTab: (url: string) =>
+  addBrowserTab: (url: string, opts?: { background?: boolean }) =>
     set((state) => {
       const ctx = getActivePanelContext(state);
       if (!ctx) return state;
@@ -663,13 +663,14 @@ export const useAppStore = create<AppState>((set, get) => ({
         rootNode: { type: "leaf", paneId, contentType: "browser", url },
         focusedPaneId: paneId,
       };
+      const background = opts?.background ?? false;
       return {
         paneContentType: { ...state.paneContentType, [paneId]: "browser" },
         paneUrl: { ...state.paneUrl, [paneId]: url },
         ...updatePanel(state, path, layout, panel.id, (p) => ({
           ...p,
           tabs: [...p.tabs, tab],
-          selectedTabId: tab.id,
+          ...(background ? {} : { selectedTabId: tab.id }),
         })),
       };
     }),

--- a/src/utils/__tests__/task-navigation.test.ts
+++ b/src/utils/__tests__/task-navigation.test.ts
@@ -29,6 +29,10 @@ vi.stubGlobal("window", {
     notifications: {
       onNavigateToTask: vi.fn(),
     },
+    projects: {
+      select: vi.fn(),
+      selectWorkspace: vi.fn(),
+    },
   },
 });
 

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -1,0 +1,51 @@
+# Manual test harnesses
+
+Interactive HTML fixtures for behavior that can't be driven by the headless
+Playwright/vitest harnesses because it requires a live Electron `<webview>` guest
+page, real `webContents.setWindowOpenHandler` dispatch, or real `BrowserWindow`
+instances.
+
+## window-targeting.html — ADR-145
+
+Covers the window/link targeting matrix from
+`docs/decisions/adr-145-webview-window-targeting/`. The automated suite covers the
+pure logic (`addBrowserTab` background behavior, `buildPopupWindowOptions`
+clamping); this page covers the end-to-end behavior that needs a real webview.
+
+### How to run
+
+1. Build & launch Manor from this branch:
+   ```
+   npm run dev          # or your usual Manor launch for the link-target-fix branch
+   ```
+2. Open a **browser tab** in Manor (Cmd+N → browser, or the New Browser command).
+3. Paste the absolute `file://` path into the URL bar, e.g.:
+   ```
+   file:///ABSOLUTE/PATH/TO/repo/tests/manual/window-targeting.html
+   ```
+4. Click through each section and watch the on-page **Log** plus the Manor tab
+   strip / window list.
+
+### Expected results (maps to the ADR matrix)
+
+| Section | Case | Expected |
+|---|---|---|
+| A: anchor `_blank` | #1 | New **foreground** Manor tab |
+| A: cmd/middle-click | #2 | New **background** Manor tab; focus stays on the harness |
+| A: anchor `_self`/`_parent`/`_top` | #3 | Navigates **this tab in place** (no new tab); Back returns |
+| B: `window.open(url)` / `_blank` | #1 | New Manor tab; handle may be `null` (tab path) |
+| B: `window.open(url, '_self'/'_parent'/'_top')` | #3 | Navigates in place, **not** a new tab |
+| C: `window.open(url, name, 'width=…')` | #5 | Separate **managed popup window** (not a tab); `popup-loaded` message logged from `window.opener` |
+| C: postMessage / close buttons | #5/#6 | opener↔popup `postMessage` round-trips; `popup.closed` flips `true` after close |
+| C: close the Manor tab/pane while popup open | #6 | Popup window also closes (parented to main window) |
+| D: iframe `window.open` / `_blank` | #4 | **Handled** (tab/popup), not silently dropped |
+| D: iframe `window.open(_parent/_top)` | #4 | Navigates **within the harness page's frame tree** — never a Manor tab |
+| D: iframe `parent.postMessage` | #4 | Reaches the top document (logged), staying internal |
+
+### Notes
+- Navigation targets use self-describing `data:` URLs so the page works offline and
+  it's obvious which target fired.
+- `_self`/`_top`/`_parent` at the top level intentionally replace the harness — that
+  *is* the correct in-place behavior. Use the browser Back button to return.
+- If a features-popup logs `window.open returned null`, that's a regression — the
+  managed-child-window path (ADR-145 ticket 3) failed to open the window.

--- a/tests/manual/frame-a.html
+++ b/tests/manual/frame-a.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>frame A</title>
+  <style>
+    body { font: 13px system-ui, sans-serif; background: #eef; color: #111; padding: .5rem; margin: 0; }
+    button { font: inherit; margin: .15rem .25rem; }
+    .tag { font-family: ui-monospace, monospace; font-weight: 700; color: #0a58ca; }
+    p { margin: .3rem 0; }
+  </style>
+</head>
+<body>
+  <b>frame A (name=frameOne)</b>
+  <p id="here"></p>
+  <button id="self"><span class="tag">E.1</span> — navigate THIS frame (self)</button>
+  <button id="msg"><span class="tag">E.2</span> — postMessage to frame B</button>
+  <button id="opennamed"><span class="tag">E.3</span> — window.open(url, 'frameTwo') → navigate sibling B</button>
+  <script>
+    function ping(m) { try { top.postMessage("frameA " + m, "*"); } catch (e) {} }
+    document.getElementById("here").textContent = "loaded: " + location.href;
+    document.getElementById("self").onclick = function () {
+      ping("E.1 self-nav");
+      location.href = "frame-a.html?nav=E.1"; // navigate only this frame
+    };
+    document.getElementById("msg").onclick = function () {
+      ping("E.2 sent");
+      try {
+        parent.frames["frameTwo"].postMessage("hello from frame A", "*");
+      } catch (e) {
+        ping("E.2 ERROR " + e);
+      }
+    };
+    document.getElementById("opennamed").onclick = function () {
+      ping("E.3 window.open(url,'frameTwo')");
+      window.open("target.html?via=E.3", "frameTwo"); // should navigate sibling, not open a tab
+    };
+  </script>
+</body>
+</html>

--- a/tests/manual/frame-b.html
+++ b/tests/manual/frame-b.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>frame B</title>
+  <style>
+    body { font: 13px system-ui, sans-serif; background: #efe; color: #111; padding: .5rem; margin: 0; }
+    .rx p { margin: .2rem 0; color: #1a7a3c; }
+  </style>
+</head>
+<body>
+  <b>frame B (name=frameTwo)</b>
+  <p id="here"></p>
+  <div class="rx" id="rx"></div>
+  <script>
+    document.getElementById("here").textContent = "loaded: " + location.href;
+    window.addEventListener("message", function (e) {
+      var p = document.createElement("p");
+      p.textContent = "B received: " + e.data;
+      document.getElementById("rx").appendChild(p);
+      // Relay to the top harness so its log captures the cross-frame delivery.
+      try { top.postMessage("frameB received: " + e.data, "*"); } catch (_) {}
+    });
+  </script>
+</body>
+</html>

--- a/tests/manual/iframe-child.html
+++ b/tests/manual/iframe-child.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>iframe child</title>
+  <style>
+    body { font: 13px system-ui, sans-serif; background: #fbfbf6; color: #111; padding: .5rem; margin: 0; }
+    button, a { font: inherit; margin: .15rem .25rem; display: inline-block; }
+    .tag { font-family: ui-monospace, monospace; font-weight: 700; color: #0a58ca; }
+  </style>
+</head>
+<body>
+  <b>iframe (child frame)</b><br />
+  <button id="open"><span class="tag">D.1</span> — iframe window.open()</button>
+  <a href="target.html?via=D.2" target="_blank"><span class="tag">D.2</span> — iframe a target=_blank</a><br />
+  <button id="parent"><span class="tag">D.3.1</span> — window.open(_parent) — navigates harness, NOT a tab</button>
+  <button id="top"><span class="tag">D.3.2</span> — window.open(_top)</button><br />
+  <button id="msg"><span class="tag">D.4</span> — parent.postMessage (stays internal)</button>
+  <script>
+    function ping(label) { try { parent.postMessage("iframe " + label, "*"); } catch (e) {} }
+    document.getElementById("open").onclick = function () {
+      ping("D.1 window.open()"); window.open("target.html?via=D.1");
+    };
+    document.getElementById("parent").onclick = function () {
+      ping("D.3.1 window.open(_parent)"); window.open("target.html?via=D.3.1", "_parent");
+    };
+    document.getElementById("top").onclick = function () {
+      ping("D.3.2 window.open(_top)"); window.open("target.html?via=D.3.2", "_top");
+    };
+    document.getElementById("msg").onclick = function () { ping("D.4 parent.postMessage"); };
+    document.querySelector("a[target=_blank]").addEventListener("click", function () {
+      ping("D.2 a target=_blank");
+    });
+  </script>
+</body>
+</html>

--- a/tests/manual/popup.html
+++ b/tests/manual/popup.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Manor popup</title>
+  <style>
+    body { font: 14px system-ui, sans-serif; background: #fff; color: #111; padding: 1rem; }
+    button { font: inherit; padding: .4rem .7rem; margin: .2rem .3rem .2rem 0;
+             border: 1px solid #bbb; border-radius: 6px; background: #f2f2f2; color: #111; cursor: pointer; }
+    #rx p { margin: .2rem 0; color: #1a7a3c; }
+  </style>
+</head>
+<body>
+  <h2>Popup window</h2>
+  <p>I am a <code>window.open()</code> popup opened with a features string.</p>
+  <button onclick="window.opener && window.opener.postMessage('hello-from-popup','*')">postMessage to opener</button>
+  <button onclick="window.close()">window.close()</button>
+  <div id="rx"></div>
+  <script>
+    window.addEventListener("message", function (e) {
+      var p = document.createElement("p");
+      p.textContent = "received from opener: " + e.data;
+      document.getElementById("rx").appendChild(p);
+    });
+    // Announce to the opener that we loaded and the opener relationship is live.
+    if (window.opener) window.opener.postMessage("popup-loaded", "*");
+  </script>
+</body>
+</html>

--- a/tests/manual/target.html
+++ b/tests/manual/target.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>target</title>
+  <style>
+    body { font: 16px system-ui, sans-serif; background: #fff; color: #111; padding: 2rem; }
+    code { background: #eee; padding: 0 .25rem; border-radius: 3px; }
+  </style>
+</head>
+<body>
+  <h1 id="h">target page</h1>
+  <p id="loc"></p>
+  <p><a href="javascript:history.back()">← back</a></p>
+  <script>
+    var via = new URLSearchParams(location.search).get("via") || "(none)";
+    document.getElementById("h").textContent = "Opened / navigated via: " + via;
+    document.getElementById("loc").textContent = "URL: " + location.href;
+    // If this page was opened with an opener (popup/named), announce it back.
+    if (window.opener) {
+      try { window.opener.postMessage("target-loaded:" + via, "*"); } catch (e) {}
+    }
+  </script>
+</body>
+</html>

--- a/tests/manual/window-targeting.html
+++ b/tests/manual/window-targeting.html
@@ -87,6 +87,17 @@
             sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-top-navigation"></iframe>
   </section>
 
+  <!-- ───────────────────────── E: same-page named frames ───────────────────────── -->
+  <h2>E. Same-page frame-to-frame (named frames)</h2>
+  <section>
+    <p class="expect"><span class="tag">E.1</span> frame self-nav → only that frame's content changes (no tab, parent stays).
+       <span class="tag">E.2</span> frame A → frame B <code>postMessage</code> → frame B logs it (relayed here as <code>frameB received: …</code>).
+       <span class="tag">E.3</span> <code>window.open(url,'frameTwo')</code> from frame A → navigates the NAMED SIBLING in place, NOT a Manor tab.
+       <span class="tag">E.4</span> named-tab reuse: click <b>B.4</b> a second time → expect a SECOND tab (no reuse — documented limitation).</p>
+    <iframe id="frameOne" name="frameOne" src="frame-a.html"></iframe>
+    <iframe id="frameTwo" name="frameTwo" src="frame-b.html"></iframe>
+  </section>
+
   <h2>Log</h2>
   <div id="log"></div>
 

--- a/tests/manual/window-targeting.html
+++ b/tests/manual/window-targeting.html
@@ -4,27 +4,29 @@
   <meta charset="utf-8" />
   <title>ADR-145 — Window/Link Targeting Manual Test Harness</title>
   <style>
-    :root { color-scheme: light dark; }
-    body { font: 14px/1.5 system-ui, sans-serif; margin: 0; padding: 1.5rem; max-width: 980px; }
-    h1 { font-size: 1.2rem; }
-    h2 { font-size: 1rem; margin-top: 1.75rem; border-bottom: 1px solid #8884; padding-bottom: .3rem; }
+    /* Explicit light theme so it stays readable regardless of OS/webview dark mode. */
+    :root { color-scheme: light; }
+    body { font: 14px/1.5 system-ui, sans-serif; margin: 0; padding: 1.5rem; max-width: 980px; background: #ffffff; color: #1a1a1a; }
+    h1 { font-size: 1.2rem; color: #111; }
+    h2 { font-size: 1rem; margin-top: 1.75rem; border-bottom: 1px solid #ccc; padding-bottom: .3rem; color: #111; }
+    p { color: #1a1a1a; }
     section { margin-bottom: .5rem; }
     button, a.btn {
       display: inline-block; margin: .2rem .3rem .2rem 0; padding: .4rem .7rem;
-      border: 1px solid #8886; border-radius: 6px; background: #8881; cursor: pointer;
-      font: inherit; text-decoration: none; color: inherit;
+      border: 1px solid #bbb; border-radius: 6px; background: #f2f2f2; color: #111; cursor: pointer;
+      font: inherit; text-decoration: none;
     }
-    button:hover, a.btn:hover { background: #8883; }
-    .expect { color: #2a7; font-size: .85rem; margin: .1rem 0 .5rem; }
-    .warn { color: #d83; }
+    button:hover, a.btn:hover { background: #e4e4e4; }
+    .expect { color: #1a7a3c; font-size: .85rem; margin: .1rem 0 .5rem; }
+    .warn { color: #b35900; }
     #log {
       margin-top: 1rem; padding: .6rem; height: 230px; overflow: auto;
-      background: #0001; border: 1px solid #8884; border-radius: 6px;
+      background: #f6f6f6; color: #111; border: 1px solid #ccc; border-radius: 6px;
       font-family: ui-monospace, monospace; font-size: 12px; white-space: pre-wrap;
     }
-    #status { font-family: ui-monospace, monospace; font-size: 12px; color: #888; }
-    iframe { width: 100%; height: 200px; border: 1px dashed #8888; border-radius: 6px; margin-top: .5rem; }
-    code { background: #8882; padding: 0 .25rem; border-radius: 3px; }
+    #status { font-family: ui-monospace, monospace; font-size: 12px; color: #555; }
+    iframe { width: 100%; height: 200px; border: 1px dashed #999; border-radius: 6px; margin-top: .5rem; background: #fff; }
+    code { background: #eee; color: #111; padding: 0 .25rem; border-radius: 3px; }
   </style>
 </head>
 <body>

--- a/tests/manual/window-targeting.html
+++ b/tests/manual/window-targeting.html
@@ -17,73 +17,74 @@
       font: inherit; text-decoration: none;
     }
     button:hover, a.btn:hover { background: #e4e4e4; }
+    .tag { font-family: ui-monospace, monospace; font-weight: 700; color: #0a58ca; }
     .expect { color: #1a7a3c; font-size: .85rem; margin: .1rem 0 .5rem; }
     .warn { color: #b35900; }
     #log {
-      margin-top: 1rem; padding: .6rem; height: 230px; overflow: auto;
+      margin-top: 1rem; padding: .6rem; height: 240px; overflow: auto;
       background: #f6f6f6; color: #111; border: 1px solid #ccc; border-radius: 6px;
       font-family: ui-monospace, monospace; font-size: 12px; white-space: pre-wrap;
     }
     #status { font-family: ui-monospace, monospace; font-size: 12px; color: #555; }
-    iframe { width: 100%; height: 200px; border: 1px dashed #999; border-radius: 6px; margin-top: .5rem; background: #fff; }
+    iframe { width: 100%; height: 220px; border: 1px dashed #999; border-radius: 6px; margin-top: .5rem; background: #fff; }
     code { background: #eee; color: #111; padding: 0 .25rem; border-radius: 3px; }
   </style>
 </head>
 <body>
   <h1>ADR-145 — Window / Link Targeting Manual Test Harness</h1>
-  <p>Load this file in a Manor browser tab (paste the <code>file://</code> path into the URL bar).
-     Each action logs its result below. Watch whether a <b>new Manor tab</b> appears, whether the
-     <b>current tab navigates in place</b>, or whether a <b>separate popup window</b> opens.</p>
+  <p>Every control is labeled (<span class="tag">A.1</span>, <span class="tag">A.3.1</span>, …) and each
+     log line below is prefixed with that label. Click a control, then read the matching line in the Log.
+     Targets are real <code>http</code> pages (browsers block <code>data:</code> targets).</p>
   <div id="status"></div>
 
-  <!-- ───────────────────────── Case 1 & 2: anchor target attributes ───────────────────────── -->
-  <h2>A. Anchor link targets (cases #1, #2, #3)</h2>
+  <!-- ───────────────────────── A: anchor target attributes ───────────────────────── -->
+  <h2>A. Anchor link targets</h2>
   <section>
-    <p class="expect">#1 <code>_blank</code> → NEW Manor tab (foreground).</p>
-    <a class="btn" href="data:text/html,<h1>Opened via _blank</h1>" target="_blank" data-log="anchor _blank">anchor target=_blank</a>
+    <p class="expect"><span class="tag">A.1</span> <code>_blank</code> → NEW Manor tab (foreground).</p>
+    <a class="btn" href="target.html?via=A.1" target="_blank" data-label="A.1">A.1 — anchor target=_blank</a>
 
-    <p class="expect">#2 cmd/middle-click any link → NEW background tab (focus stays here).</p>
-    <a class="btn" href="data:text/html,<h1>Opened via background tab</h1>" target="_blank" data-log="anchor cmd/middle-click">cmd/middle-click me</a>
+    <p class="expect"><span class="tag">A.2</span> cmd/middle-click → NEW background tab (focus stays here).</p>
+    <a class="btn" href="target.html?via=A.2" target="_blank" data-label="A.2">A.2 — cmd/middle-click me</a>
 
-    <p class="expect warn">#3 <code>_self</code>/<code>_parent</code>/<code>_top</code> → navigate THIS tab in place
-       (replaces the harness — use Back to return). Should NOT open a new tab.</p>
-    <a class="btn" href="data:text/html,<h1>Navigated in place via _self</h1><a href='javascript:history.back()'>back</a>" target="_self" data-log="anchor _self">anchor target=_self</a>
-    <a class="btn" href="data:text/html,<h1>Navigated in place via _top</h1><a href='javascript:history.back()'>back</a>" target="_top" data-log="anchor _top">anchor target=_top</a>
-    <a class="btn" href="data:text/html,<h1>Navigated in place via _parent</h1><a href='javascript:history.back()'>back</a>" target="_parent" data-log="anchor _parent">anchor target=_parent</a>
+    <p class="expect warn"><span class="tag">A.3.1–A.3.3</span> <code>_self</code>/<code>_top</code>/<code>_parent</code> →
+       navigate THIS tab in place (replaces harness — use Back to return). NOT a new tab.</p>
+    <a class="btn" href="target.html?via=A.3.1" target="_self" data-label="A.3.1">A.3.1 — anchor target=_self</a>
+    <a class="btn" href="target.html?via=A.3.2" target="_top" data-label="A.3.2">A.3.2 — anchor target=_top</a>
+    <a class="btn" href="target.html?via=A.3.3" target="_parent" data-label="A.3.3">A.3.3 — anchor target=_parent</a>
   </section>
 
-  <!-- ───────────────────────── window.open variants ───────────────────────── -->
-  <h2>B. window.open() targets (cases #1, #3)</h2>
+  <!-- ───────────────────────── B: window.open variants ───────────────────────── -->
+  <h2>B. window.open() targets</h2>
   <section>
     <p class="expect">Featureless <code>window.open</code> → NEW Manor tab. <code>_self/_parent/_top</code> → in place.</p>
-    <button data-open="blank">window.open(url) — no target</button>
-    <button data-open="_blank">window.open(url, '_blank')</button>
-    <button data-open="_self">window.open(url, '_self')</button>
-    <button data-open="_parent">window.open(url, '_parent')</button>
-    <button data-open="_top">window.open(url, '_top')</button>
-    <button data-open="named">window.open(url, 'namedTab') — twice to test reuse</button>
+    <button data-open="blank" data-label="B.1">B.1 — window.open(url) no target</button>
+    <button data-open="_blank" data-label="B.2">B.2 — window.open(url, '_blank')</button>
+    <button data-open="_self" data-label="B.3.1">B.3.1 — window.open(url, '_self')</button>
+    <button data-open="_parent" data-label="B.3.2">B.3.2 — window.open(url, '_parent')</button>
+    <button data-open="_top" data-label="B.3.3">B.3.3 — window.open(url, '_top')</button>
+    <button data-open="named" data-label="B.4">B.4 — window.open(url, 'namedTab')</button>
   </section>
 
-  <!-- ───────────────────────── Case 5 & 6: communicating popup ───────────────────────── -->
-  <h2>C. Communicating popup — OAuth/SSO style (cases #5, #6)</h2>
+  <!-- ───────────────────────── C: communicating popup ───────────────────────── -->
+  <h2>C. Communicating popup — OAuth/SSO style</h2>
   <section>
-    <p class="expect">#5 <code>window.open(url, name, 'width=…,height=…')</code> → separate managed popup WINDOW
-       (not a tab). The popup posts a message back to <code>window.opener</code>; you should see it logged below.</p>
-    <button id="openPopup">Open popup (with features)</button>
-    <button id="msgPopup" disabled>opener → popup.postMessage('ping')</button>
-    <button id="closePopup" disabled>opener calls popup.close()</button>
-    <p class="expect">#6 Watch <code>popup.closed</code> flip to <code>true</code> after closing the popup or this pane.
-       Closing this Manor tab/pane should also close the popup (parented to the main window).</p>
+    <p class="expect"><span class="tag">C.1</span> <code>window.open(url, name, 'width=…,height=…')</code> →
+       separate managed popup WINDOW (not a tab); logs <code>popup-loaded</code> from <code>window.opener</code>.</p>
+    <button id="openPopup">C.1 — Open popup (with features)</button>
+    <p class="expect"><span class="tag">C.2</span> opener → popup round-trip. <span class="tag">C.3</span> opener closes popup;
+       <code>popup.closed</code> flips <code>true</code>.</p>
+    <button id="msgPopup" disabled>C.2 — opener → popup.postMessage('ping')</button>
+    <button id="closePopup" disabled>C.3 — opener calls popup.close()</button>
   </section>
 
-  <!-- ───────────────────────── Case 4: iframe / frame-to-frame ───────────────────────── -->
-  <h2>D. Inside an &lt;iframe&gt; — frame-to-frame (case #4)</h2>
+  <!-- ───────────────────────── D: iframe / frame-to-frame ───────────────────────── -->
+  <h2>D. Inside an &lt;iframe&gt; — frame-to-frame</h2>
   <section>
-    <p class="expect">#4 <code>window.open</code> from inside the iframe must be HANDLED (new tab / popup per its target),
-       not silently dropped. <code>_parent</code>/<code>_top</code> from the iframe should navigate
-       <b>within this page's frame tree</b> — never spill out into a Manor tab.
-       <code>parent.postMessage</code> should reach the top document (logged below), staying internal.</p>
-    <iframe id="frame" sandbox="allow-scripts allow-popups allow-same-origin allow-top-navigation"></iframe>
+    <p class="expect"><span class="tag">D.1/D.2</span> iframe <code>window.open</code> / <code>_blank</code> → HANDLED (new tab), not dropped.
+       <span class="tag">D.3.1/D.3.2</span> iframe <code>_parent</code>/<code>_top</code> → navigate within this page's frame tree, NEVER a Manor tab.
+       <span class="tag">D.4</span> <code>parent.postMessage</code> → reaches the top document (logged), staying internal.</p>
+    <iframe id="frame" src="iframe-child.html"
+            sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-top-navigation"></iframe>
   </section>
 
   <h2>Log</h2>
@@ -100,89 +101,60 @@
     }
     statusEl.textContent = "location: " + location.href;
 
-    // A self-describing data: URL navigation target (offline-safe, identifiable).
-    function targetUrl(via) {
-      return "data:text/html,<title>" + via + "</title>" +
-        "<h1>window.open via " + via + "</h1>" +
-        "<p>If this is a separate Manor tab/window, " + via + " spawned a new context. " +
-        "If it replaced the harness, it navigated in place.</p>" +
-        "<a href='javascript:history.back()'>back</a>";
-    }
+    function targetUrl(via) { return "target.html?via=" + encodeURIComponent(via); }
 
-    // Section A — anchors: log the click (navigation/new-tab handled by Manor).
-    document.querySelectorAll("a[data-log]").forEach((a) => {
-      a.addEventListener("click", () => log("clicked " + a.dataset.log + " → " + a.getAttribute("target")));
+    // A — anchors: log with label (navigation/new-tab handled by Manor).
+    document.querySelectorAll("a[data-label]").forEach((a) => {
+      a.addEventListener("click", () =>
+        log(`[${a.dataset.label}] clicked anchor target=${a.getAttribute("target")}`));
     });
 
-    // Section B — window.open variants.
+    // B — window.open variants.
     document.querySelectorAll("button[data-open]").forEach((b) => {
       b.addEventListener("click", () => {
         const t = b.dataset.open;
-        const target = t === "blank" ? undefined : t;
-        const via = t === "blank" ? "(no target)" : t;
-        const handle = window.open(targetUrl(via), target);
-        log(`window.open(url, ${JSON.stringify(target)}) → handle is ${handle ? "a WindowProxy" : "null"}`);
+        const target = t === "blank" ? undefined : t === "named" ? "namedTab" : t;
+        const handle = window.open(targetUrl(b.dataset.label), target);
+        log(`[${b.dataset.label}] window.open(url, ${JSON.stringify(target)}) → handle is ${handle ? "WindowProxy" : "null"}`);
       });
     });
 
-    // Section C — communicating popup with features + opener round-trip.
+    // C — communicating popup with features + opener round-trip.
     let popup = null;
     const openBtn = document.getElementById("openPopup");
     const msgBtn = document.getElementById("msgPopup");
     const closeBtn = document.getElementById("closePopup");
 
-    const popupDoc =
-      "data:text/html," + encodeURIComponent(
-        "<title>Manor popup</title><body style='font:14px system-ui;padding:1rem'>" +
-        "<h2>Popup window</h2><p>I am a window.open() popup with features.</p>" +
-        "<button onclick=\"window.opener && window.opener.postMessage('hello-from-popup','*')\">postMessage to opener</button> " +
-        "<button onclick='window.close()'>window.close()</button>" +
-        "<script>" +
-        "window.addEventListener('message', (e)=>{document.body.insertAdjacentHTML('beforeend','<p>received from opener: '+e.data+'</p>')});" +
-        "if(window.opener){window.opener.postMessage('popup-loaded','*')}" +
-        "<\/script></body>");
-
     openBtn.addEventListener("click", () => {
-      popup = window.open(popupDoc, "manorAuthPopup", "width=520,height=620");
+      popup = window.open("popup.html", "manorAuthPopup", "width=520,height=620");
       if (popup) {
-        log("opened popup with features → handle is a WindowProxy (expect a separate popup window)");
+        log("[C.1] opened popup with features → handle is WindowProxy (expect a separate popup window)");
         msgBtn.disabled = false;
         closeBtn.disabled = false;
         const poll = setInterval(() => {
           if (!popup || popup.closed) {
-            log("popup.closed === true (case #6: lifecycle observed)");
+            log("[C.3] popup.closed === true (lifecycle observed)");
             msgBtn.disabled = true;
             closeBtn.disabled = true;
             clearInterval(poll);
           }
         }, 500);
       } else {
-        log("window.open returned null — popup was NOT created (BUG: features-popup should open a window)");
+        log("[C.1] window.open returned null — popup NOT created (BUG: features-popup should open a window)");
       }
     });
     msgBtn.addEventListener("click", () => {
-      if (popup && !popup.closed) { popup.postMessage("ping-from-opener", "*"); log("opener → popup.postMessage('ping-from-opener')"); }
-      else log("no live popup handle");
+      if (popup && !popup.closed) { popup.postMessage("ping-from-opener", "*"); log("[C.2] opener → popup.postMessage('ping-from-opener')"); }
+      else log("[C.2] no live popup handle");
     });
     closeBtn.addEventListener("click", () => {
-      if (popup) { popup.close(); log("called popup.close() from opener"); }
+      if (popup) { popup.close(); log("[C.3] opener called popup.close()"); }
     });
-    window.addEventListener("message", (e) => log("opener received message: " + JSON.stringify(e.data)));
 
-    // Section D — iframe content (self-contained via srcdoc).
-    const frame = document.getElementById("frame");
-    frame.srcdoc =
-      "<body style='font:13px system-ui;padding:.5rem'>" +
-      "<b>iframe (child frame)</b><br>" +
-      "<button onclick=\"window.open('data:text/html,<h1>iframe window.open</h1>')\">iframe window.open()</button> " +
-      "<a href='data:text/html,<h1>iframe _blank</h1>' target='_blank'>iframe a _blank</a><br>" +
-      "<button onclick=\"window.open('data:text/html,<h1>iframe _parent</h1><a href=%5C'javascript:history.back()%5C'>back</a>','_parent')\">window.open(_parent) — navigates the harness, not a tab</button> " +
-      "<button onclick=\"window.open('data:text/html,<h1>iframe _top</h1><a href=%5C'javascript:history.back()%5C'>back</a>','_top')\">window.open(_top)</button><br>" +
-      "<button onclick=\"parent.postMessage('hello-from-iframe','*')\">parent.postMessage (stays internal)</button>" +
-      "<script>document.addEventListener('click',(e)=>{if(e.target.tagName==='BUTTON'||e.target.tagName==='A')parent.postMessage('iframe-action:'+e.target.textContent,'*')})<\/script>" +
-      "</body>";
+    // Messages from popup (C) and iframe (D.4) land here.
+    window.addEventListener("message", (e) => log(`[msg] opener received: ${JSON.stringify(e.data)}`));
 
-    log("harness loaded. open DevTools console to mirror this log.");
+    log("harness loaded (labeled, http targets). open DevTools console to mirror this log.");
   </script>
 </body>
 </html>

--- a/tests/manual/window-targeting.html
+++ b/tests/manual/window-targeting.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>ADR-145 — Window/Link Targeting Manual Test Harness</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font: 14px/1.5 system-ui, sans-serif; margin: 0; padding: 1.5rem; max-width: 980px; }
+    h1 { font-size: 1.2rem; }
+    h2 { font-size: 1rem; margin-top: 1.75rem; border-bottom: 1px solid #8884; padding-bottom: .3rem; }
+    section { margin-bottom: .5rem; }
+    button, a.btn {
+      display: inline-block; margin: .2rem .3rem .2rem 0; padding: .4rem .7rem;
+      border: 1px solid #8886; border-radius: 6px; background: #8881; cursor: pointer;
+      font: inherit; text-decoration: none; color: inherit;
+    }
+    button:hover, a.btn:hover { background: #8883; }
+    .expect { color: #2a7; font-size: .85rem; margin: .1rem 0 .5rem; }
+    .warn { color: #d83; }
+    #log {
+      margin-top: 1rem; padding: .6rem; height: 230px; overflow: auto;
+      background: #0001; border: 1px solid #8884; border-radius: 6px;
+      font-family: ui-monospace, monospace; font-size: 12px; white-space: pre-wrap;
+    }
+    #status { font-family: ui-monospace, monospace; font-size: 12px; color: #888; }
+    iframe { width: 100%; height: 200px; border: 1px dashed #8888; border-radius: 6px; margin-top: .5rem; }
+    code { background: #8882; padding: 0 .25rem; border-radius: 3px; }
+  </style>
+</head>
+<body>
+  <h1>ADR-145 — Window / Link Targeting Manual Test Harness</h1>
+  <p>Load this file in a Manor browser tab (paste the <code>file://</code> path into the URL bar).
+     Each action logs its result below. Watch whether a <b>new Manor tab</b> appears, whether the
+     <b>current tab navigates in place</b>, or whether a <b>separate popup window</b> opens.</p>
+  <div id="status"></div>
+
+  <!-- ───────────────────────── Case 1 & 2: anchor target attributes ───────────────────────── -->
+  <h2>A. Anchor link targets (cases #1, #2, #3)</h2>
+  <section>
+    <p class="expect">#1 <code>_blank</code> → NEW Manor tab (foreground).</p>
+    <a class="btn" href="data:text/html,<h1>Opened via _blank</h1>" target="_blank" data-log="anchor _blank">anchor target=_blank</a>
+
+    <p class="expect">#2 cmd/middle-click any link → NEW background tab (focus stays here).</p>
+    <a class="btn" href="data:text/html,<h1>Opened via background tab</h1>" target="_blank" data-log="anchor cmd/middle-click">cmd/middle-click me</a>
+
+    <p class="expect warn">#3 <code>_self</code>/<code>_parent</code>/<code>_top</code> → navigate THIS tab in place
+       (replaces the harness — use Back to return). Should NOT open a new tab.</p>
+    <a class="btn" href="data:text/html,<h1>Navigated in place via _self</h1><a href='javascript:history.back()'>back</a>" target="_self" data-log="anchor _self">anchor target=_self</a>
+    <a class="btn" href="data:text/html,<h1>Navigated in place via _top</h1><a href='javascript:history.back()'>back</a>" target="_top" data-log="anchor _top">anchor target=_top</a>
+    <a class="btn" href="data:text/html,<h1>Navigated in place via _parent</h1><a href='javascript:history.back()'>back</a>" target="_parent" data-log="anchor _parent">anchor target=_parent</a>
+  </section>
+
+  <!-- ───────────────────────── window.open variants ───────────────────────── -->
+  <h2>B. window.open() targets (cases #1, #3)</h2>
+  <section>
+    <p class="expect">Featureless <code>window.open</code> → NEW Manor tab. <code>_self/_parent/_top</code> → in place.</p>
+    <button data-open="blank">window.open(url) — no target</button>
+    <button data-open="_blank">window.open(url, '_blank')</button>
+    <button data-open="_self">window.open(url, '_self')</button>
+    <button data-open="_parent">window.open(url, '_parent')</button>
+    <button data-open="_top">window.open(url, '_top')</button>
+    <button data-open="named">window.open(url, 'namedTab') — twice to test reuse</button>
+  </section>
+
+  <!-- ───────────────────────── Case 5 & 6: communicating popup ───────────────────────── -->
+  <h2>C. Communicating popup — OAuth/SSO style (cases #5, #6)</h2>
+  <section>
+    <p class="expect">#5 <code>window.open(url, name, 'width=…,height=…')</code> → separate managed popup WINDOW
+       (not a tab). The popup posts a message back to <code>window.opener</code>; you should see it logged below.</p>
+    <button id="openPopup">Open popup (with features)</button>
+    <button id="msgPopup" disabled>opener → popup.postMessage('ping')</button>
+    <button id="closePopup" disabled>opener calls popup.close()</button>
+    <p class="expect">#6 Watch <code>popup.closed</code> flip to <code>true</code> after closing the popup or this pane.
+       Closing this Manor tab/pane should also close the popup (parented to the main window).</p>
+  </section>
+
+  <!-- ───────────────────────── Case 4: iframe / frame-to-frame ───────────────────────── -->
+  <h2>D. Inside an &lt;iframe&gt; — frame-to-frame (case #4)</h2>
+  <section>
+    <p class="expect">#4 <code>window.open</code> from inside the iframe must be HANDLED (new tab / popup per its target),
+       not silently dropped. <code>_parent</code>/<code>_top</code> from the iframe should navigate
+       <b>within this page's frame tree</b> — never spill out into a Manor tab.
+       <code>parent.postMessage</code> should reach the top document (logged below), staying internal.</p>
+    <iframe id="frame" sandbox="allow-scripts allow-popups allow-same-origin allow-top-navigation"></iframe>
+  </section>
+
+  <h2>Log</h2>
+  <div id="log"></div>
+
+  <script>
+    const logEl = document.getElementById("log");
+    const statusEl = document.getElementById("status");
+    function log(msg) {
+      const t = new Date().toLocaleTimeString();
+      logEl.textContent += `[${t}] ${msg}\n`;
+      logEl.scrollTop = logEl.scrollHeight;
+      console.log("[adr-145-harness] " + msg);
+    }
+    statusEl.textContent = "location: " + location.href;
+
+    // A self-describing data: URL navigation target (offline-safe, identifiable).
+    function targetUrl(via) {
+      return "data:text/html,<title>" + via + "</title>" +
+        "<h1>window.open via " + via + "</h1>" +
+        "<p>If this is a separate Manor tab/window, " + via + " spawned a new context. " +
+        "If it replaced the harness, it navigated in place.</p>" +
+        "<a href='javascript:history.back()'>back</a>";
+    }
+
+    // Section A — anchors: log the click (navigation/new-tab handled by Manor).
+    document.querySelectorAll("a[data-log]").forEach((a) => {
+      a.addEventListener("click", () => log("clicked " + a.dataset.log + " → " + a.getAttribute("target")));
+    });
+
+    // Section B — window.open variants.
+    document.querySelectorAll("button[data-open]").forEach((b) => {
+      b.addEventListener("click", () => {
+        const t = b.dataset.open;
+        const target = t === "blank" ? undefined : t;
+        const via = t === "blank" ? "(no target)" : t;
+        const handle = window.open(targetUrl(via), target);
+        log(`window.open(url, ${JSON.stringify(target)}) → handle is ${handle ? "a WindowProxy" : "null"}`);
+      });
+    });
+
+    // Section C — communicating popup with features + opener round-trip.
+    let popup = null;
+    const openBtn = document.getElementById("openPopup");
+    const msgBtn = document.getElementById("msgPopup");
+    const closeBtn = document.getElementById("closePopup");
+
+    const popupDoc =
+      "data:text/html," + encodeURIComponent(
+        "<title>Manor popup</title><body style='font:14px system-ui;padding:1rem'>" +
+        "<h2>Popup window</h2><p>I am a window.open() popup with features.</p>" +
+        "<button onclick=\"window.opener && window.opener.postMessage('hello-from-popup','*')\">postMessage to opener</button> " +
+        "<button onclick='window.close()'>window.close()</button>" +
+        "<script>" +
+        "window.addEventListener('message', (e)=>{document.body.insertAdjacentHTML('beforeend','<p>received from opener: '+e.data+'</p>')});" +
+        "if(window.opener){window.opener.postMessage('popup-loaded','*')}" +
+        "<\/script></body>");
+
+    openBtn.addEventListener("click", () => {
+      popup = window.open(popupDoc, "manorAuthPopup", "width=520,height=620");
+      if (popup) {
+        log("opened popup with features → handle is a WindowProxy (expect a separate popup window)");
+        msgBtn.disabled = false;
+        closeBtn.disabled = false;
+        const poll = setInterval(() => {
+          if (!popup || popup.closed) {
+            log("popup.closed === true (case #6: lifecycle observed)");
+            msgBtn.disabled = true;
+            closeBtn.disabled = true;
+            clearInterval(poll);
+          }
+        }, 500);
+      } else {
+        log("window.open returned null — popup was NOT created (BUG: features-popup should open a window)");
+      }
+    });
+    msgBtn.addEventListener("click", () => {
+      if (popup && !popup.closed) { popup.postMessage("ping-from-opener", "*"); log("opener → popup.postMessage('ping-from-opener')"); }
+      else log("no live popup handle");
+    });
+    closeBtn.addEventListener("click", () => {
+      if (popup) { popup.close(); log("called popup.close() from opener"); }
+    });
+    window.addEventListener("message", (e) => log("opener received message: " + JSON.stringify(e.data)));
+
+    // Section D — iframe content (self-contained via srcdoc).
+    const frame = document.getElementById("frame");
+    frame.srcdoc =
+      "<body style='font:13px system-ui;padding:.5rem'>" +
+      "<b>iframe (child frame)</b><br>" +
+      "<button onclick=\"window.open('data:text/html,<h1>iframe window.open</h1>')\">iframe window.open()</button> " +
+      "<a href='data:text/html,<h1>iframe _blank</h1>' target='_blank'>iframe a _blank</a><br>" +
+      "<button onclick=\"window.open('data:text/html,<h1>iframe _parent</h1><a href=%5C'javascript:history.back()%5C'>back</a>','_parent')\">window.open(_parent) — navigates the harness, not a tab</button> " +
+      "<button onclick=\"window.open('data:text/html,<h1>iframe _top</h1><a href=%5C'javascript:history.back()%5C'>back</a>','_top')\">window.open(_top)</button><br>" +
+      "<button onclick=\"parent.postMessage('hello-from-iframe','*')\">parent.postMessage (stays internal)</button>" +
+      "<script>document.addEventListener('click',(e)=>{if(e.target.tagName==='BUTTON'||e.target.tagName==='A')parent.postMessage('iframe-action:'+e.target.textContent,'*')})<\/script>" +
+      "</body>";
+
+    log("harness loaded. open DevTools console to mirror this log.");
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## ADR-145: Correct window/link targeting & popup semantics in browser webviews

Fixes how Manor's browser panes handle `window.open` / link `target`s. Replaces the injected-JS new-window interception with Electron's native `setWindowOpenHandler` on the guest `WebContents`, routing by intent.

Full design + decision record: `docs/decisions/adr-145-webview-window-targeting/`.

### Bugs fixed
- **`window.open(url, '_parent')` (and `_self`/`_top`) opened a new tab instead of navigating in place** — the original report. The injected override dropped the target argument and flattened everything to "new tab." Now these surface as same-frame navigation and never reach the handler.
- **`window.open` from inside an `<iframe>` was silently dropped** — the intercept script only ran in the main frame. The native handler fires for all frames.

### What changed
- Native `setWindowOpenHandler` routes by `disposition`/`features`: navigation-style opens (`_blank`, cmd/middle-click) → Manor tab; communicating popups (`new-window` / features string) → a **real managed child `BrowserWindow`** so the Chromium opener relationship (`window.opener`, `postMessage`, `closed`, `close()`) works end-to-end for OAuth/SSO/payment flows; `_self`/`_parent`/`_top` pass through as in-place navigation.
- `<webview allowpopups>` enabled so guest opens reach the handler.
- Background-tab disposition threaded through IPC so cmd/middle-click doesn't steal focus.
- Injected `INTERCEPT_NEW_WINDOW_SCRIPT` + its console-message listener removed.

### Tickets (all done)
1. Native `setWindowOpenHandler` + remove injected JS
2. Thread background-tab disposition through new-window IPC
3. Managed child window for communicating popups
4. Tests for targeting & popup routing

## Live validation

Validated by hand in a dev build via `tests/manual/window-targeting.html` (a loadable harness; the matrix can't be driven headlessly because `window.open`/popups require a real user gesture). **The full matrix passed** — anchor targets, `window.open` variants, the communicating popup (separate window + bidirectional `postMessage` + `close()` both ways), iframe new-windows, and same-page named-frame navigation/messaging. Named-tab reuse across `<webview>`s is confirmed unsupported (documented limitation).

> **Regression caught only by the live run:** ticket 1 set `allowpopups` as a boolean prop, which **React 19 silently drops for `<webview>`**, leaving the attribute absent — so Electron blocked *every* guest `window.open`/`target=_blank` before the handler ran. typecheck/build/unit tests were all green; only the real app surfaced it. Fixed by emitting `allowpopups` as a string attribute.

## Unrelated fixes bundled in this branch

These were found/needed while validating ADR-145 and are folded in here (each is its own commit, easy to cherry-pick out if you'd rather land them separately):

- **`fix(browser): navigate explicit URL schemes`** — the URL bar routed anything that wasn't `http(s)`/localhost/dotted-domain to a Google search, so typing a `file:`/`data:`/`about:` URL searched instead of navigating. Broadened the passthrough guard.
- **`fix(diff-watcher): ignore directories that aren't git repos`** — a non-git workspace path logged `git diff failed … not a git repository` every 5s tick. Now skipped silently and cached so it isn't rescanned.
- **`fix(mcp-webview): resolve port per request` + `fall back to port file when env port is stale`** — the webview MCP server cached its target port at startup and broke (`Cannot connect to Manor`) after any Manor restart, requiring a manual reconnect. Now resolves the port per request and falls back from the stale `MANOR_WEBVIEW_PORT` env to the live port file, so it self-heals across restarts.
- **`chore(adr-145): … fix test mocks`** (+ harness commits) — the shared store-test `setup.ts` mock omitted `electronAPI.tasks`/`notifications`, which `task-store.ts` calls at module-init, crashing several suites on import; and `task-navigation.test.ts` omitted `projects.select`/`selectWorkspace`. Added them (+27 passing tests). Quick, safe mock fixes only.

## Test status / pre-existing failures

typecheck is clean apart from 6 **pre-existing** errors in two untouched test files. The suite has **983 passing**; the remaining failures are all **pre-existing and unrelated** to this branch (verified failing at the merge base):

- `electron/__tests__/tasks-unseen-source-of-truth.test.ts` (×2) — mocks the `electron` module differently; separate harness.
- `electron/backend/__tests__/local-git-pushstream.integration.test.ts` — real-git integration, environment-dependent.
- `src/store/__tests__/app-store-close-pane-abandon.test.ts` — the test asserts `abandonForPane("pane-1")` but the code calls `abandonForPane(paneId, currentTitle)`; a one-line assertion mismatch. **Left as-is** (unrelated, needs a behavioral judgment) — easy follow-up.
- `src/store/__tests__/agent-status-store.test.ts` "deduplicates" — flaky under suite-level test pollution (passes in isolation).

None are introduced by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
