### PR TITLE
fix(adr-145): harden the ZDOTDIR shim so global zsh history reaches ~/.zsh_history

### DIFF
--- a/docs/decisions/adr-145-harden-zdotdir-shim/index.md
+++ b/docs/decisions/adr-145-harden-zdotdir-shim/index.md
@@ -1,6 +1,6 @@
 ---
 type: adr
-status: proposed
+status: accepted
 database:
   schema:
     status:

--- a/docs/decisions/adr-145-harden-zdotdir-shim/index.md
+++ b/docs/decisions/adr-145-harden-zdotdir-shim/index.md
@@ -1,0 +1,194 @@
+---
+type: adr
+status: proposed
+database:
+  schema:
+    status:
+      type: select
+      options: [todo, in-progress, review, done]
+      default: todo
+    priority:
+      type: select
+      options: [critical, high, medium, low]
+    assignee:
+      type: select
+      options: [opus, sonnet, haiku]
+  defaultView: board
+  groupBy: status
+---
+
+# ADR-145: Harden the ZDOTDIR shim (global history that actually reaches `~/.zsh_history`)
+
+## Context
+
+ADR-143 introduced a `ZDOTDIR` shim: Manor points `ZDOTDIR` at a private dir
+(`<dataDir>/zdotdir`) holding generated `.zshenv`/`.zprofile`/`.zshrc`/`.zlogin`
+that each source the user's real dotfile, then inject Manor's additions (OSC 7
+CWD reporting, shared history). This is the standard non-invasive
+shell-integration trick — it adds behavior without editing the user's dotfiles.
+
+ADR-144 then changed the history block from *override* to *honor-with-fallback*:
+`: "${HISTFILE:=${REAL_ZDOTDIR:-$HOME}/.zsh_history}"` — the intent being to
+write to the user's **real, global** `~/.zsh_history` so `ctrl+r` flows in and
+out of Manor.
+
+**ADR-144's fix does not work on macOS.** Investigation (v0.5.12) found Manor
+panes still writing history to `<dataDir>/zdotdir/.zsh_history` — a Manor-private
+file with today's commands (`claude --dangerously-skip-permissions`, `npm run
+dev`, `git co development; git-up; git-purge`) — while the real `~/.zsh_history`
+(15,700+ lines) only ever sees the launching terminal. The isolation ADR-144
+meant to kill simply relocated from `<dataDir>/shell-history` to
+`<dataDir>/zdotdir/.zsh_history`.
+
+### Root cause: `/etc/zshrc` pins `HISTFILE` to `$ZDOTDIR` before our `.zshrc` runs
+
+macOS ships `/etc/zshrc` with an **unconditional** assignment (line 16):
+
+```zsh
+HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history
+```
+
+zsh's interactive-login startup order is:
+
+| Step | File | Effect |
+|------|------|--------|
+| 2 | `$ZDOTDIR/.zshenv` → real `.zshenv` | (custom HISTFILE here is later clobbered) |
+| 4 | `$ZDOTDIR/.zprofile` → real `.zprofile` | (clobbered too) |
+| 5 | **`/etc/zshrc`** | `HISTFILE = $ZDOTDIR/.zsh_history` — and our ZDOTDIR override points it at the Manor dir |
+| 6 | `$ZDOTDIR/.zshrc` → real `.zshrc` (oh-my-zsh), then Manor's history block | |
+
+By step 6, `HISTFILE` is already set to the Manor dir. oh-my-zsh's
+`[ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"` is conditional → no-op.
+Manor's `: "${HISTFILE:=…}"` is also conditional → no-op. So Manor honors a value
+that `/etc/zshrc` poisoned via our own `ZDOTDIR` override. ADR-144 reasoned about
+only two `HISTFILE` states ("user set it" / "unset → fallback") and missed the
+third, which is the **default on macOS**: set by the system to `$ZDOTDIR/...`.
+
+Reproduced directly: even with `REAL_ZDOTDIR=$HOME` and oh-my-zsh loading
+correctly, `HISTFILE` resolves to `<Manor zdotdir>/.zsh_history`.
+
+### Second root cause: `REAL_ZDOTDIR` poisoning under nested launch
+
+Both spawn sites compute `REAL_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME`
+(`electron/pty.ts:30`, `electron/terminal-host/session.ts:234`). The `:-$HOME`
+fallback in the generated scripts guards against `ZDOTDIR` being *unset* — but
+not against it being set to **Manor's own dir**. When the Manor app process
+itself inherits `ZDOTDIR=<Manor zdotdir>` (e.g. `npm run dev` launched from a
+Manor pane — the standard dev workflow), `REAL_ZDOTDIR` resolves to the Manor
+dir. Then the generated `.zshrc` sources `${REAL_ZDOTDIR}/.zshrc` = **its own
+file**, so oh-my-zsh / theme / aliases / functions never load at all in those
+panes, and the HISTFILE fallback writes into the Manor dir. This is a broader
+breakage than history alone.
+
+### General principle
+
+Every `${ZDOTDIR:-$HOME}/X` reference anywhere in the startup chain — system,
+framework, or user — silently retargets from `$HOME` to Manor's private dir.
+`HISTFILE` is the first casualty; `.zcompdump` is another (Manor keeps a separate
+completion dump). We fix the two that affect correctness and accept the rest.
+
+## Decision
+
+Three targeted changes; do **not** globally reset `ZDOTDIR` (that would break OSC
+7 CWD tracking in nested `exec zsh` subshells, which rely on the Manor ZDOTDIR
+persisting).
+
+### 1. Redirect `HISTFILE` when it points inside `$ZDOTDIR` (`electron/shell.ts`)
+
+Replace the honor-only `:=` fallback with a guard that distinguishes the three
+states by the time Manor's block runs (after sourcing the real `.zshrc`):
+
+```zsh
+# /etc/zshrc on macOS sets HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history before this
+# block runs, and our ZDOTDIR override poisons it to Manor's private dir. Reclaim
+# the global file when HISTFILE is empty or lives inside our ZDOTDIR; honor any
+# genuinely custom path the user set in their real .zshrc (it won't be under our
+# dir — they don't know it exists).
+if [[ -z "$HISTFILE" || "$HISTFILE" == "$ZDOTDIR"/* ]]; then
+  HISTFILE="${REAL_ZDOTDIR:-$HOME}/.zsh_history"
+fi
+```
+
+- **`$ZDOTDIR/.zsh_history`** (the macOS default, poisoned by us) → redirect to
+  the real global file.
+- **Custom absolute path** set in the user's `.zshrc` (the only user file that
+  survives `/etc/zshrc`, since it runs at step 6) → honored; it can't collide
+  with the `$ZDOTDIR/*` test because users never point `HISTFILE` inside Manor's
+  app-support dir.
+- **Empty** → fallback (unchanged from ADR-144's intent).
+
+`HISTSIZE`/`SAVEHIST` floors and `setopt SHARE_HISTORY` are retained verbatim.
+
+### 2. Sanitize `REAL_ZDOTDIR` against nested launches (Node side)
+
+Add `ShellManager.realZdotdir()` in `electron/shell.ts` (Electron-free, importable
+by both the main process and the daemon):
+
+```ts
+static realZdotdir(): string {
+  const inherited = process.env.ZDOTDIR;
+  // If the app inherited OUR own zdotdir (e.g. Manor launched from a Manor pane),
+  // it is not a real user ZDOTDIR — fall back to HOME so the generated scripts
+  // source the user's real dotfiles instead of recursively sourcing themselves.
+  if (inherited && inherited !== this.zdotdirPath()) return inherited;
+  return process.env.HOME ?? "";
+}
+```
+
+Use it at both spawn sites in place of `process.env.ZDOTDIR || process.env.HOME`:
+`electron/pty.ts:30` and `electron/terminal-host/session.ts:234`.
+
+### 3. Source the user's `~/.zlogout` (`electron/shell.ts`)
+
+Manor generates `.zshenv`/`.zprofile`/`.zshrc`/`.zlogin` but **no `.zlogout`**, so
+zsh never runs the user's real `~/.zlogout` cleanup on pane exit. Add a generated
+`.zlogout` matching the others:
+
+```zsh
+[[ -f "${REAL_ZDOTDIR:-$HOME}/.zlogout" ]] && source "${REAL_ZDOTDIR:-$HOME}/.zlogout"
+```
+
+### Not in scope (accepted as-is)
+
+- **`.zcompdump` duplication.** zsh's `compinit` writes
+  `${ZDOTDIR:-$HOME}/.zcompdump-*`, so Manor keeps a separate completion dump.
+  This is a regenerable cache; the only cost is one rebuild per zsh-version bump.
+  Sharing it reliably would require reconstructing oh-my-zsh's host/version dump
+  filename in our pre-source snippet — fragile, for no correctness gain. Left
+  alone deliberately.
+- **Globally resetting `ZDOTDIR`** to the real dir after Manor's block. Rejected:
+  it would strip Manor's OSC 7 integration from nested interactive shells
+  (`exec zsh`, subshells) that re-resolve `$ZDOTDIR`.
+
+## Consequences
+
+**Better:**
+- `ctrl+r` and up-arrow in any Manor pane recall the user's entire real
+  `~/.zsh_history` — and Manor commands flow back out to the launching terminal,
+  live via `SHARE_HISTORY`. This is what ADR-144 promised and macOS silently
+  defeated.
+- Panes spawned by a Manor instance that was itself launched from a Manor pane
+  (the `npm run dev` workflow) now load oh-my-zsh, the user's theme, aliases, and
+  functions instead of recursively sourcing Manor's own stub `.zshrc`.
+- `~/.zlogout` cleanup hooks run on pane exit.
+
+**Worse / risks:**
+- Manor/agent commands continue to land in the real `~/.zsh_history` (e.g.
+  `claude --dangerously-skip-permissions`) — the explicit, intended trade from
+  ADR-144, now actually realized.
+- The `$ZDOTDIR/*` guard assumes a user's genuinely-custom `HISTFILE` never lives
+  inside Manor's app-support dir. Safe by construction (that path is Manor's
+  invention) but stated here.
+- `.zcompdump` duplication persists (accepted above).
+- Pre-existing stray files (`<dataDir>/zdotdir/.zsh_history`,
+  `<dataDir>/shell-history`) are orphaned, consistent with ADR-143/144's
+  no-migration stance. The lost commands are acceptable to the user.
+
+This **supersedes the mechanism of ADR-144** (honor-only `HISTFILE`) while
+preserving its decision (one shared, global history with `SHARE_HISTORY`).
+ADR-144 stays `accepted`; this extends it. zsh only; bash/fish are unaffected
+(already global, no shim).
+
+## Tickets
+
+<div data-type="database" data-path="." data-view="board"></div>

--- a/docs/decisions/adr-145-harden-zdotdir-shim/ticket-1-sanitize-real-zdotdir.md
+++ b/docs/decisions/adr-145-harden-zdotdir-shim/ticket-1-sanitize-real-zdotdir.md
@@ -1,0 +1,62 @@
+---
+title: Sanitize REAL_ZDOTDIR against nested launches
+status: in-progress
+priority: critical
+assignee: sonnet
+blocked_by: []
+---
+
+# Sanitize REAL_ZDOTDIR against nested launches
+
+When the Manor app process itself inherits `ZDOTDIR=<Manor zdotdir>` (e.g. `npm
+run dev` launched from inside a Manor pane), both PTY spawn sites compute
+`REAL_ZDOTDIR = process.env.ZDOTDIR || process.env.HOME` and end up with Manor's
+own dir. The generated `.zshrc` then sources `${REAL_ZDOTDIR}/.zshrc` = itself,
+so oh-my-zsh / theme / aliases never load and history falls back into the Manor
+dir.
+
+Fix: introduce a single sanitized resolver and use it at both spawn sites. If the
+inherited `ZDOTDIR` is Manor's own zdotdir, treat it as absent and fall back to
+`HOME`.
+
+## Implementation
+
+1. In `electron/shell.ts`, add a static method to `ShellManager`:
+
+   ```ts
+   static realZdotdir(): string {
+     const inherited = process.env.ZDOTDIR;
+     // If the app inherited OUR own zdotdir (Manor launched from a Manor pane),
+     // it is not a real user ZDOTDIR — fall back to HOME so the generated scripts
+     // source the user's real dotfiles instead of recursively sourcing themselves.
+     if (inherited && inherited !== this.zdotdirPath()) return inherited;
+     return process.env.HOME ?? "";
+   }
+   ```
+
+   `zdotdirPath()` already exists on `ShellManager` and returns `shellZdotdir()`.
+
+2. Replace the inline `REAL_ZDOTDIR` computation at both call sites with
+   `ShellManager.realZdotdir()`:
+   - `electron/pty.ts:30` — currently
+     `REAL_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME || ""`. `ShellManager`
+     is already imported in this file.
+   - `electron/terminal-host/session.ts:234` — same expression inside the
+     `buildShellEnv(...)` overrides object. `ShellManager` is already imported.
+
+3. Add a unit test (extend `electron/__tests__/shell.test.ts` or add a focused
+   `describe`) covering `ShellManager.realZdotdir()`:
+   - returns `HOME` when `process.env.ZDOTDIR` is unset
+   - returns `HOME` when `process.env.ZDOTDIR` equals `ShellManager.zdotdirPath()`
+     (the nested-launch poison case)
+   - returns the inherited value when `process.env.ZDOTDIR` is a real, different
+     dir
+   Save/restore `process.env.ZDOTDIR` and `process.env.HOME` around the test.
+   Note the existing test file mocks `../paths` so `shellZdotdir()` returns a
+   fixed temp `zdotdir` path — assert against that same value.
+
+## Files to touch
+- `electron/shell.ts` — add `static realZdotdir()` to `ShellManager`.
+- `electron/pty.ts` — use `ShellManager.realZdotdir()` for the `REAL_ZDOTDIR` env var.
+- `electron/terminal-host/session.ts` — use `ShellManager.realZdotdir()` for the `REAL_ZDOTDIR` env var.
+- `electron/__tests__/shell.test.ts` — unit tests for `realZdotdir()`.

--- a/docs/decisions/adr-145-harden-zdotdir-shim/ticket-1-sanitize-real-zdotdir.md
+++ b/docs/decisions/adr-145-harden-zdotdir-shim/ticket-1-sanitize-real-zdotdir.md
@@ -1,6 +1,6 @@
 ---
 title: Sanitize REAL_ZDOTDIR against nested launches
-status: in-progress
+status: done
 priority: critical
 assignee: sonnet
 blocked_by: []

--- a/docs/decisions/adr-145-harden-zdotdir-shim/ticket-2-harden-generated-scripts.md
+++ b/docs/decisions/adr-145-harden-zdotdir-shim/ticket-2-harden-generated-scripts.md
@@ -1,6 +1,6 @@
 ---
 title: Redirect poisoned HISTFILE and source .zlogout in generated scripts
-status: in-progress
+status: done
 priority: critical
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-145-harden-zdotdir-shim/ticket-2-harden-generated-scripts.md
+++ b/docs/decisions/adr-145-harden-zdotdir-shim/ticket-2-harden-generated-scripts.md
@@ -1,6 +1,6 @@
 ---
 title: Redirect poisoned HISTFILE and source .zlogout in generated scripts
-status: todo
+status: in-progress
 priority: critical
 assignee: sonnet
 blocked_by: [1]

--- a/docs/decisions/adr-145-harden-zdotdir-shim/ticket-2-harden-generated-scripts.md
+++ b/docs/decisions/adr-145-harden-zdotdir-shim/ticket-2-harden-generated-scripts.md
@@ -1,0 +1,77 @@
+---
+title: Redirect poisoned HISTFILE and source .zlogout in generated scripts
+status: todo
+priority: critical
+assignee: sonnet
+blocked_by: [1]
+---
+
+# Redirect poisoned HISTFILE and source .zlogout in generated scripts
+
+macOS `/etc/zshrc` sets `HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history` unconditionally,
+*before* Manor's `.zshrc` block runs. Because Manor overrides `ZDOTDIR` to its own
+dir, `HISTFILE` is poisoned to `<Manor zdotdir>/.zsh_history` and ADR-144's
+honor-only `:=` fallback is a no-op. Replace it with a guard that redirects when
+`HISTFILE` is empty OR lives inside `$ZDOTDIR`, while honoring a genuinely custom
+user path. Also generate a `.zlogout` so the user's real `~/.zlogout` runs.
+
+## Implementation
+
+In `electron/shell.ts`, inside `setupZdotdir()`:
+
+1. In the generated `.zshrc` body, replace the current line:
+
+   ```zsh
+   : "${HISTFILE:=${REAL_ZDOTDIR:-$HOME}/.zsh_history}"
+   ```
+
+   with:
+
+   ```zsh
+   # /etc/zshrc on macOS sets HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history before this
+   # block runs, and our ZDOTDIR override poisons it to Manor's private dir. Reclaim
+   # the global file when HISTFILE is empty or lives inside our ZDOTDIR; honor any
+   # genuinely custom path the user set in their real .zshrc (it won't be under our
+   # dir — they don't know it exists).
+   if [[ -z "$HISTFILE" || "$HISTFILE" == "$ZDOTDIR"/* ]]; then
+     HISTFILE="${REAL_ZDOTDIR:-$HOME}/.zsh_history"
+   fi
+   ```
+
+   Keep this block in its current position — AFTER the `source` of the user's real
+   `.zshrc` and BEFORE the `HISTSIZE`/`SAVEHIST` floors and `setopt SHARE_HISTORY`
+   (all retained verbatim). Mind the existing TS template-literal escaping in this
+   file: `${...}` that must reach the shell verbatim is written `\${...}` in the
+   source, and `$ZDOTDIR` / `$HISTFILE` are fine as-is. Match the escaping style
+   already used for the neighboring `${HISTFILE:=${REAL_ZDOTDIR:-$HOME}/...}` and
+   `${HOST}`/`${PWD}` lines.
+
+2. Add a `.zlogout` entry to the `files` array (same source-the-real-one pattern
+   as `.zshenv`/`.zprofile`/`.zlogin`):
+
+   ```ts
+   [
+     ".zlogout",
+     `[[ -f "\${REAL_ZDOTDIR:-$HOME}/.zlogout" ]] && source "\${REAL_ZDOTDIR:-$HOME}/.zlogout"\n`,
+   ],
+   ```
+
+## Tests — `electron/__tests__/shell.test.ts`
+
+Update the "shared history" describe block:
+- Replace the `: "${HISTFILE:=` assertion (currently in the
+  "provides a :=-fallback" test) with assertions for the new guard:
+  - contains `if [[ -z "$HISTFILE" || "$HISTFILE" == "$ZDOTDIR"/* ]]; then`
+  - contains `HISTFILE="${REAL_ZDOTDIR:-$HOME}/.zsh_history"`
+- Keep and keep-passing: no Manor `shell-history` path; no `MANOR_HISTFILE`;
+  `setopt SHARE_HISTORY` present; `HISTSIZE`/`SAVEHIST` floors present.
+- Update the ordering test ("places the HISTFILE fallback after sourcing …") to
+  assert `zshrc.indexOf("source") < zshrc.indexOf("HISTFILE=")` (the new redirect
+  uses `HISTFILE=` assignment, not `HISTFILE:=`).
+- Add a test asserting a `.zlogout` file is generated and sources
+  `${REAL_ZDOTDIR:-$HOME}/.zlogout` (read it from the temp `zdotdir`, mirroring
+  how `generatedZshrc()` reads `.zshrc`).
+
+## Files to touch
+- `electron/shell.ts` — HISTFILE redirect guard + `.zlogout` generation in `setupZdotdir()`.
+- `electron/__tests__/shell.test.ts` — update history assertions, add `.zlogout` test.

--- a/electron/__tests__/shell.test.ts
+++ b/electron/__tests__/shell.test.ts
@@ -20,6 +20,11 @@ function generatedZshrc(): string {
   return fs.readFileSync(path.join(zdotdir, ".zshrc"), "utf-8");
 }
 
+function generatedZlogout(): string {
+  ShellManager.setupZdotdir();
+  return fs.readFileSync(path.join(zdotdir, ".zlogout"), "utf-8");
+}
+
 describe("ShellManager.setupZdotdir — shared history", () => {
   beforeEach(() => {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
@@ -33,8 +38,12 @@ describe("ShellManager.setupZdotdir — shared history", () => {
     expect(generatedZshrc()).not.toContain("shell-history");
   });
 
-  it("provides a :=-fallback for HISTFILE after sourcing the user's .zshrc", () => {
-    expect(generatedZshrc()).toContain(': "${HISTFILE:=');
+  it("redirects HISTFILE when it is empty or lives inside Manor's ZDOTDIR", () => {
+    const zshrc = generatedZshrc();
+    expect(zshrc).toContain(
+      'if [[ -z "$HISTFILE" || "$HISTFILE" == "$ZDOTDIR"/* ]]; then',
+    );
+    expect(zshrc).toContain('HISTFILE="${REAL_ZDOTDIR:-$HOME}/.zsh_history"');
   });
 
   it("does not depend on the daemon-injected MANOR_HISTFILE env var", () => {
@@ -51,9 +60,15 @@ describe("ShellManager.setupZdotdir — shared history", () => {
     expect(zshrc).toContain("(( SAVEHIST < 100000 )) && SAVEHIST=100000");
   });
 
-  it("places the HISTFILE fallback after sourcing the user's real .zshrc so their value wins", () => {
+  it("places the HISTFILE redirect after sourcing the user's real .zshrc so their value wins", () => {
     const zshrc = generatedZshrc();
-    expect(zshrc.indexOf("source")).toBeLessThan(zshrc.indexOf("HISTFILE:="));
+    expect(zshrc.indexOf("source")).toBeLessThan(zshrc.indexOf("HISTFILE="));
+  });
+
+  it("generates a .zlogout that sources the user's real .zlogout", () => {
+    expect(generatedZlogout()).toContain(
+      'source "${REAL_ZDOTDIR:-$HOME}/.zlogout"',
+    );
   });
 });
 

--- a/electron/__tests__/shell.test.ts
+++ b/electron/__tests__/shell.test.ts
@@ -56,3 +56,33 @@ describe("ShellManager.setupZdotdir — shared history", () => {
     expect(zshrc.indexOf("source")).toBeLessThan(zshrc.indexOf("HISTFILE:="));
   });
 });
+
+describe("ShellManager.realZdotdir — nested-launch sanitization", () => {
+  const savedZdotdir = process.env.ZDOTDIR;
+  const savedHome = process.env.HOME;
+
+  afterEach(() => {
+    if (savedZdotdir === undefined) delete process.env.ZDOTDIR;
+    else process.env.ZDOTDIR = savedZdotdir;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+  });
+
+  it("returns HOME when ZDOTDIR is unset", () => {
+    delete process.env.ZDOTDIR;
+    process.env.HOME = "/home/user";
+    expect(ShellManager.realZdotdir()).toBe("/home/user");
+  });
+
+  it("falls back to HOME when ZDOTDIR equals Manor's own zdotdir (nested-launch poison)", () => {
+    process.env.ZDOTDIR = ShellManager.zdotdirPath();
+    process.env.HOME = "/home/user";
+    expect(ShellManager.realZdotdir()).toBe("/home/user");
+  });
+
+  it("returns the inherited ZDOTDIR when it is a real, different dir", () => {
+    process.env.ZDOTDIR = "/home/user/.config/zsh";
+    process.env.HOME = "/home/user";
+    expect(ShellManager.realZdotdir()).toBe("/home/user/.config/zsh");
+  });
+});

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -27,7 +27,7 @@ export class PtyManager {
       MANOR_PANE_ID: paneId,
       TERM: "xterm-256color",
       ZDOTDIR: zdotdir,
-      REAL_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME || "",
+      REAL_ZDOTDIR: ShellManager.realZdotdir(),
     };
 
     const ptyProcess = pty.spawn(shell, [], {

--- a/electron/shell.ts
+++ b/electron/shell.ts
@@ -8,6 +8,15 @@ export class ShellManager {
     return shellZdotdir();
   }
 
+  static realZdotdir(): string {
+    const inherited = process.env.ZDOTDIR;
+    // If the app inherited OUR own zdotdir (Manor launched from a Manor pane),
+    // it is not a real user ZDOTDIR — fall back to HOME so the generated scripts
+    // source the user's real dotfiles instead of recursively sourcing themselves.
+    if (inherited && inherited !== this.zdotdirPath()) return inherited;
+    return process.env.HOME ?? "";
+  }
+
   static setupZdotdir(): string {
     const dir = this.zdotdirPath();
     fs.mkdirSync(dir, { recursive: true });

--- a/electron/shell.ts
+++ b/electron/shell.ts
@@ -33,10 +33,14 @@ export class ShellManager {
       [
         ".zshrc",
         `[[ -f "\${REAL_ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${REAL_ZDOTDIR:-$HOME}/.zshrc"
-# Global history shared in and out of Manor — honor whatever HISTFILE the user's
-# .zshrc resolved (oh-my-zsh and most configs set ~/.zsh_history); fall back to
-# ~/.zsh_history only if the sourced .zshrc left it unset.
-: "\${HISTFILE:=\${REAL_ZDOTDIR:-$HOME}/.zsh_history}"
+# /etc/zshrc on macOS sets HISTFILE=\${ZDOTDIR:-$HOME}/.zsh_history before this
+# block runs, and our ZDOTDIR override poisons it to Manor's private dir. Reclaim
+# the global file when HISTFILE is empty or lives inside our ZDOTDIR; honor any
+# genuinely custom path the user set in their real .zshrc (it won't be under our
+# dir — they don't know it exists).
+if [[ -z "$HISTFILE" || "$HISTFILE" == "$ZDOTDIR"/* ]]; then
+  HISTFILE="\${REAL_ZDOTDIR:-$HOME}/.zsh_history"
+fi
 # Guarantee the shared history is deep enough to be useful without shrinking a
 # user who already set a larger value in their real .zshrc (sourced above).
 (( HISTSIZE < 100000 )) && HISTSIZE=100000
@@ -57,6 +61,10 @@ precmd_functions+=(__manor_osc7_precmd)
       [
         ".zlogin",
         `[[ -f "\${REAL_ZDOTDIR:-$HOME}/.zlogin" ]] && source "\${REAL_ZDOTDIR:-$HOME}/.zlogin"\n`,
+      ],
+      [
+        ".zlogout",
+        `[[ -f "\${REAL_ZDOTDIR:-$HOME}/.zlogout" ]] && source "\${REAL_ZDOTDIR:-$HOME}/.zlogout"\n`,
       ],
     ];
 

--- a/electron/terminal-host/session.ts
+++ b/electron/terminal-host/session.ts
@@ -231,7 +231,7 @@ export class Session {
             MANOR_PANE_ID: this.sessionId,
             TERM: "xterm-256color",
             ZDOTDIR: zdotdir,
-            REAL_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME || "",
+            REAL_ZDOTDIR: ShellManager.realZdotdir(),
             ...this.envOverrides,
           }),
         };


### PR DESCRIPTION
## Summary

ADR-144 meant to make Manor panes share the user's **real, global** `~/.zsh_history`, but the fix silently fails on macOS. This PR makes it actually work, plus fixes a related nested-launch breakage and a `.zlogout` gap.

See `docs/decisions/adr-145-harden-zdotdir-shim/index.md` for the full decision record.

### Root cause 1 — `/etc/zshrc` poisons `HISTFILE`
macOS `/etc/zshrc` runs *between* the user's `.zshenv` and `.zshrc` and **unconditionally** sets `HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history`. Because Manor overrides `ZDOTDIR` to its own private dir, `HISTFILE` is pinned to `<dataDir>/zdotdir/.zsh_history` before Manor's block runs — so ADR-144's honor-only `:=` fallback (and oh-my-zsh's `[ -z "$HISTFILE" ]`) are both no-ops. Result: history kept landing in a Manor-private file, exactly the isolation ADR-144 tried to remove.

**Fix:** redirect when the value is empty or lives inside `$ZDOTDIR`, while honoring a genuinely custom user path:
```zsh
if [[ -z "$HISTFILE" || "$HISTFILE" == "$ZDOTDIR"/* ]]; then
  HISTFILE="${REAL_ZDOTDIR:-$HOME}/.zsh_history"
fi
```

### Root cause 2 — `REAL_ZDOTDIR` poisoning under nested launch
When the Manor process itself inherits `ZDOTDIR=<Manor dir>` (e.g. `npm run dev` from a Manor pane), `REAL_ZDOTDIR` resolved to Manor's own dir and the generated `.zshrc` sourced *itself* — so oh-my-zsh / theme / aliases never loaded. New `ShellManager.realZdotdir()` treats an inherited Manor `ZDOTDIR` as absent and falls back to `$HOME`.

### Also
- Generate a `.zlogout` so the user's real `~/.zlogout` cleanup runs on pane exit.
- `.zcompdump` duplication is deliberately left as an accepted harmless cache (see ADR).

## Changes
- `electron/shell.ts` — `realZdotdir()` helper; HISTFILE redirect guard; `.zlogout` generation.
- `electron/pty.ts`, `electron/terminal-host/session.ts` — use `realZdotdir()` for `REAL_ZDOTDIR`.
- `electron/__tests__/shell.test.ts` — guard + `.zlogout` + `realZdotdir()` tests.

## Testing
- 10/10 shell tests pass; no new typecheck errors; `vite build` succeeds.
- End-to-end zsh test confirms all three HISTFILE cases: poisoned `$ZDOTDIR` value → redirected to global file; unset → fallback; custom path → honored untouched.

This supersedes the *mechanism* of ADR-144 while preserving its decision (one shared global history with `SHARE_HISTORY`). zsh only; bash/fish unaffected.