### PR TITLE
refactor: share addErrorToast helper across issue components

### DIFF
--- a/src/components/command-palette/GitHubIssueDetailView.tsx
+++ b/src/components/command-palette/GitHubIssueDetailView.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import ArrowLeft from "lucide-react/dist/esm/icons/arrow-left";
 import { useAppStore } from "../../store/app-store";
 import { useProjectStore } from "../../store/project-store";
-import { useToastStore } from "../../store/toast-store";
+import { addErrorToast } from "../../store/toast-store";
 import { stripMarkdown } from "./utils";
 import { IssueDetailSkeleton } from "./IssueDetailSkeleton";
 import type { CommandPaletteProps } from "./types";
@@ -34,12 +34,11 @@ type GitHubIssueDetailViewProps = {
  */
 function assignIssueBestEffort(repoPath: string, issueNumber: number): void {
   window.electronAPI.github.assignIssue(repoPath, issueNumber).catch((err) => {
-    useToastStore.getState().addToast({
-      id: `assign-issue-error-gh-${issueNumber}`,
-      message: "Failed to assign issue",
-      status: "error",
-      detail: err instanceof Error ? err.message : String(err),
-    });
+    addErrorToast(
+      `assign-issue-error-gh-${issueNumber}`,
+      "Failed to assign issue",
+      err,
+    );
   });
 }
 
@@ -144,13 +143,11 @@ export function GitHubIssueDetailView(props: GitHubIssueDetailViewProps) {
         `gh-${issueNumber}`,
       );
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      useToastStore.getState().addToast({
-        id: `unlink-issue-error-gh-${issueNumber}`,
-        message: "Failed to unlink issue",
-        status: "error",
-        detail: message,
-      });
+      addErrorToast(
+        `unlink-issue-error-gh-${issueNumber}`,
+        "Failed to unlink issue",
+        err,
+      );
       return;
     }
     onClose();
@@ -162,13 +159,11 @@ export function GitHubIssueDetailView(props: GitHubIssueDetailViewProps) {
     try {
       await window.electronAPI.github.closeIssue(repoPath, issueNumber);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      useToastStore.getState().addToast({
-        id: `close-issue-error-gh-${issueNumber}`,
-        message: "Failed to close issue",
-        status: "error",
-        detail: message,
-      });
+      addErrorToast(
+        `close-issue-error-gh-${issueNumber}`,
+        "Failed to close issue",
+        err,
+      );
       return;
     }
     onClose();
@@ -181,13 +176,11 @@ export function GitHubIssueDetailView(props: GitHubIssueDetailViewProps) {
     } catch (err) {
       // The issue genuinely is closed now — surface the stale link without
       // undoing the close.
-      const message = err instanceof Error ? err.message : String(err);
-      useToastStore.getState().addToast({
-        id: `unlink-after-close-error-gh-${issueNumber}`,
-        message: "Issue closed, but failed to unlink from workspace",
-        status: "error",
-        detail: message,
-      });
+      addErrorToast(
+        `unlink-after-close-error-gh-${issueNumber}`,
+        "Issue closed, but failed to unlink from workspace",
+        err,
+      );
       return;
     }
     useProjectStore.getState().loadProjects();

--- a/src/components/statusbar/LinkedIssuesPopover/LinkedIssuesPopover.tsx
+++ b/src/components/statusbar/LinkedIssuesPopover/LinkedIssuesPopover.tsx
@@ -12,7 +12,7 @@ import { GitHubIssueDetailView } from "../../command-palette/GitHubIssueDetailVi
 import { LinearIcon } from "../../command-palette/LinearIcon";
 import { GitHubIcon } from "../../command-palette/GitHubIcon";
 import { useProjectStore } from "../../../store/project-store";
-import { useToastStore } from "../../../store/toast-store";
+import { addErrorToast, useToastStore } from "../../../store/toast-store";
 import styles from "./LinkedIssuesPopover.module.css";
 
 type IssueDetail =
@@ -273,16 +273,6 @@ export function LinkedIssuesPopover(props: LinkedIssuesPopoverProps) {
     });
   }, []);
 
-  const toastError = useCallback((id: string, message: string, err: unknown) => {
-    const detail = err instanceof Error ? err.message : String(err);
-    useToastStore.getState().addToast({
-      id,
-      message,
-      status: "error",
-      detail,
-    });
-  }, []);
-
   const handleUnlink = useCallback(
     async (issueId: string) => {
       setRemovedIds((prev) => new Set(prev).add(issueId));
@@ -300,12 +290,12 @@ export function LinkedIssuesPopover(props: LinkedIssuesPopoverProps) {
       } catch (err) {
         // Revert the optimistic removal — the link still exists on disk.
         revertRemoval(issueId);
-        toastError(`unlink-issue-error-${issueId}`, "Failed to unlink issue", err);
+        addErrorToast(`unlink-issue-error-${issueId}`, "Failed to unlink issue", err);
         return;
       }
       useProjectStore.getState().loadProjects();
     },
-    [projectId, workspacePath, visibleIssues, onClose, revertRemoval, toastError],
+    [projectId, workspacePath, visibleIssues, onClose, revertRemoval],
   );
 
   const handleCloseTicket = useCallback(
@@ -325,7 +315,7 @@ export function LinkedIssuesPopover(props: LinkedIssuesPopoverProps) {
       } catch (err) {
         // Revert the optimistic removal — the issue is still open.
         revertRemoval(issueId);
-        toastError(`close-issue-error-${issueId}`, "Failed to close issue", err);
+        addErrorToast(`close-issue-error-${issueId}`, "Failed to close issue", err);
         return;
       }
       try {
@@ -337,7 +327,7 @@ export function LinkedIssuesPopover(props: LinkedIssuesPopoverProps) {
       } catch (err) {
         // The issue genuinely is closed now — do not revert the removal,
         // just surface that the workspace link is stale.
-        toastError(
+        addErrorToast(
           `unlink-after-close-error-${issueId}`,
           "Issue closed, but failed to unlink from workspace",
           err,
@@ -346,7 +336,7 @@ export function LinkedIssuesPopover(props: LinkedIssuesPopoverProps) {
       }
       useProjectStore.getState().loadProjects();
     },
-    [projectId, workspacePath, repoPath, visibleIssues, onClose, revertRemoval, toastError],
+    [projectId, workspacePath, repoPath, visibleIssues, onClose, revertRemoval],
   );
 
   const handleRowClick = useCallback((issueId: string) => {

--- a/src/store/toast-store.ts
+++ b/src/store/toast-store.ts
@@ -21,6 +21,21 @@ interface ToastState {
   removeToast: (id: string) => void;
 }
 
+/**
+ * Surface an error to the user as a toast. Normalizes `unknown` to a string
+ * detail (`Error.message`, else `String(err)`) — the shape every catch block was
+ * hand-rolling. Pass a stable `id` so a repeated failure replaces its toast
+ * rather than stacking (see `addToast`'s dedupe).
+ */
+export function addErrorToast(id: string, message: string, err: unknown): void {
+  useToastStore.getState().addToast({
+    id,
+    message,
+    status: "error",
+    detail: err instanceof Error ? err.message : String(err),
+  });
+}
+
 export const useToastStore = create<ToastState>((set) => ({
   toasts: [],
 


### PR DESCRIPTION
GitHubIssueDetailView inlined the `err instanceof Error ? err.message : String(err)` + error-toast dance 4 times; LinkedIssuesPopover had extracted it into a local `toastError`. Promote one canonical `addErrorToast(id, message, err)` onto toast-store and route both components through it.

Toast payloads are byte-identical — pure de-duplication, no behavior change. The popover's Linear-auth toast stays direct: it carries a custom action.