### PR TITLE
ADR-162: Notification center

### DIFF
--- a/docs/decisions/adr-162-notification-center/index.md
+++ b/docs/decisions/adr-162-notification-center/index.md
@@ -1,6 +1,6 @@
 ---
 type: adr
-status: proposed
+status: accepted
 database:
   schema:
     status:

--- a/docs/decisions/adr-162-notification-center/ticket-1-notification-store.md
+++ b/docs/decisions/adr-162-notification-center/ticket-1-notification-store.md
@@ -1,6 +1,6 @@
 ---
 title: Main-side NotificationStore with persistence and retention
-status: todo
+status: done
 priority: critical
 assignee: sonnet
 blocked_by: []

--- a/docs/decisions/adr-162-notification-center/ticket-2-record-and-ipc.md
+++ b/docs/decisions/adr-162-notification-center/ticket-2-record-and-ipc.md
@@ -1,6 +1,6 @@
 ---
 title: Record every notification at emit, expose it over IPC
-status: todo
+status: done
 priority: critical
 assignee: opus
 blocked_by: [1]

--- a/docs/decisions/adr-162-notification-center/ticket-3-renderer-store-and-navigation.md
+++ b/docs/decisions/adr-162-notification-center/ticket-3-renderer-store-and-navigation.md
@@ -1,6 +1,6 @@
 ---
 title: Renderer notification store and shared navigation helper
-status: todo
+status: done
 priority: high
 assignee: sonnet
 blocked_by: [2]

--- a/docs/decisions/adr-162-notification-center/ticket-4-extract-date-buckets.md
+++ b/docs/decisions/adr-162-notification-center/ticket-4-extract-date-buckets.md
@@ -1,6 +1,6 @@
 ---
 title: Extract day bucketing out of TasksView
-status: in-progress
+status: done
 priority: medium
 assignee: haiku
 blocked_by: []

--- a/docs/decisions/adr-162-notification-center/ticket-5-bell-and-popover.md
+++ b/docs/decisions/adr-162-notification-center/ticket-5-bell-and-popover.md
@@ -1,6 +1,6 @@
 ---
 title: Bell entry point and notifications popover
-status: todo
+status: done
 priority: high
 assignee: opus
 blocked_by: [3, 4]

--- a/electron/__tests__/relay-subagent-tracking.test.ts
+++ b/electron/__tests__/relay-subagent-tracking.test.ts
@@ -1280,6 +1280,71 @@ describe("createHookRelay — ADR-135 ticket-4: monotonic sweep clock", () => {
   });
 });
 
+describe("createHookRelay — ADR-162: a session that opens needing input notifies", () => {
+  let ctx: ReturnType<typeof buildRelay>;
+
+  beforeEach(() => {
+    ctx = buildRelay();
+  });
+
+  it("adr162-1: the first task-creating event notifies when it already requires input", () => {
+    const { relay, taskManager, maybeSendNotification, unseenInputTasks } = ctx;
+
+    // An agent that asks for permission before doing anything else: the very
+    // first event that creates a task already carries requires_input, so only
+    // CreateTask runs for it. Skipping the notification here left the pulse
+    // showing with no banner and nothing in the notification log.
+    fire(relay, notification({ paneId: "pane-N", sessionId: "sess-N" }));
+
+    const task = taskManager.getTaskBySessionId("sess-N");
+    expect(task).not.toBeNull();
+    expect(task?.lastAgentStatus).toBe("requires_input");
+    expect(unseenInputTasks.has(task!.id)).toBe(true);
+
+    expect(maybeSendNotification).toHaveBeenCalledTimes(1);
+    expect(maybeSendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ id: task!.id }),
+      // No prior task means no prior status.
+      null,
+      "requires_input",
+    );
+  });
+
+  it("adr162-2: creating a task mid-turn does not notify", () => {
+    const { relay, maybeSendNotification } = ctx;
+
+    // "thinking" is not a state anyone is told about — only responded and
+    // requires_input are, and the preference gates live in the callee.
+    fire(relay, userPromptSubmit({ paneId: "pane-T", sessionId: "sess-T" }));
+
+    expect(maybeSendNotification).toHaveBeenCalledTimes(1);
+    expect(maybeSendNotification).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      "thinking",
+    );
+  });
+
+  it("adr162-3: a session handed off to a new one still notifies for the new task", () => {
+    const { relay, taskManager, maybeSendNotification } = ctx;
+
+    fire(relay, userPromptSubmit({ paneId: "pane-H", sessionId: "sess-H1" }));
+    maybeSendNotification.mockClear();
+
+    // Handoff on the same pane: CreateTask retires the old task first, then
+    // creates one that already needs input.
+    fire(relay, sessionStart({ paneId: "pane-H", sessionId: "sess-H2" }));
+    fire(relay, notification({ paneId: "pane-H", sessionId: "sess-H2" }));
+
+    const newTask = taskManager.getTaskBySessionId("sess-H2");
+    expect(maybeSendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ id: newTask!.id }),
+      null,
+      "requires_input",
+    );
+  });
+});
+
 describe("createHookRelay — ADR-142: CreateTask retires previous pane owner", () => {
   let ctx: ReturnType<typeof buildRelay>;
 

--- a/electron/app-lifecycle.ts
+++ b/electron/app-lifecycle.ts
@@ -21,6 +21,7 @@ import {
 import { createHookRelay, SWEEP_INTERVAL_MS } from "./hook-relay";
 import { ensureWebviewCli } from "./webview-cli-script";
 import { TaskManager, type TaskInfo } from "./task-persistence";
+import { NotificationStore } from "./notification-store";
 import { PreferencesManager } from "./preferences";
 import { KeybindingsManager } from "./keybindings";
 import { cleanAgentTitle } from "./title-utils";
@@ -41,6 +42,7 @@ import {
   updateDockBadge as _updateDockBadge,
   maybeSendNotification as _maybeSendNotification,
   sendTaskUpdate,
+  setNotificationStore,
 } from "./notifications";
 import * as ptyIpc from "./ipc/pty";
 import * as layoutIpc from "./ipc/layout";
@@ -52,6 +54,7 @@ import { killAllActivePushes } from "./ipc/branches-diffs";
 import * as integrationsIpc from "./ipc/integrations";
 import * as webviewIpc from "./ipc/webview";
 import * as tasksIpc from "./ipc/tasks";
+import * as notificationsIpc from "./ipc/notifications";
 import * as miscIpc from "./ipc/misc";
 import * as processesIpc from "./ipc/processes";
 import * as windowIpc from "./ipc/window";
@@ -187,6 +190,10 @@ export function initApp(devTitle: string | null): void {
     preferencesManager.get("taskRetentionDays"),
   );
   const keybindingsManager = new KeybindingsManager();
+  // ADR-162's durable notification log. Handed to `notifications.ts` so the
+  // single recording site inside `presentNotification` can reach it.
+  const notificationStore = new NotificationStore();
+  setNotificationStore(notificationStore);
 
   // ADR-161's remote-control surface. Constructed here so the status sink and
   // the quit hook can see it; deliberately *not* started — remote control is
@@ -320,6 +327,7 @@ export function initApp(devTitle: string | null): void {
     linearManager,
     agentHookServer,
     taskManager,
+    notificationStore,
     preferencesManager,
     keybindingsManager,
     paneContextMap,
@@ -340,6 +348,7 @@ export function initApp(devTitle: string | null): void {
   integrationsIpc.register(ipcDeps);
   webviewIpc.register(ipcDeps);
   tasksIpc.register(ipcDeps);
+  notificationsIpc.register(ipcDeps);
   miscIpc.register(ipcDeps);
   processesIpc.register(ipcDeps);
   windowIpc.register(ipcDeps);

--- a/electron/hook-relay-effects.ts
+++ b/electron/hook-relay-effects.ts
@@ -125,10 +125,20 @@ export function applyEffects(
         });
         const now = new Date().toISOString();
         task = deps.taskManager.updateTask(task.id, { activatedAt: now });
-        if (task && effect.status === "requires_input") {
-          deps.unseenInputTasks.add(task.id);
+        if (task) {
+          if (effect.status === "requires_input") {
+            deps.unseenInputTasks.add(task.id);
+          }
+          // A session whose very first task-creating event already needs input
+          // — an agent that asks for permission before doing anything else —
+          // notifies like any other transition into that state. Only this
+          // branch runs for it: there is no prior task for
+          // `UpdateTaskActiveStatus` to find, and skipping the call here meant
+          // the pulse appeared with no banner and no entry in the log
+          // (ADR-162).
+          deps.maybeSendNotification(task, null, effect.status);
+          deps.broadcastTask(task);
         }
-        if (task) deps.broadcastTask(task);
         break;
       }
 

--- a/electron/ipc/index.ts
+++ b/electron/ipc/index.ts
@@ -8,6 +8,7 @@ import * as branchesDiffsIpc from "./branches-diffs";
 import * as integrationsIpc from "./integrations";
 import * as webviewIpc from "./webview";
 import * as tasksIpc from "./tasks";
+import * as notificationsIpc from "./notifications";
 import * as miscIpc from "./misc";
 import * as processesIpc from "./processes";
 import * as windowIpc from "./window";
@@ -25,6 +26,7 @@ export function registerAllIpc(deps: IpcDeps): void {
   integrationsIpc.register(deps);
   webviewIpc.register(deps);
   tasksIpc.register(deps);
+  notificationsIpc.register(deps);
   miscIpc.register(deps);
   processesIpc.register(deps);
   windowIpc.register(deps);

--- a/electron/ipc/misc.ts
+++ b/electron/ipc/misc.ts
@@ -3,7 +3,11 @@ import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { assertString } from "../ipc-validate";
-import { playNotificationSound, showPrNotification } from "../notifications";
+import {
+  playNotificationSound,
+  showPrNotification,
+  type PrNotifyEventKind,
+} from "../notifications";
 import { checkForUpdates, quitAndInstall } from "../updater";
 import type { IpcDeps } from "./types";
 
@@ -123,7 +127,15 @@ export function register(deps: IpcDeps): void {
    */
   ipcMain.handle(
     "notifications:show",
-    (event, payload: { title: string; body: string; url?: string }): boolean => {
+    (
+      event,
+      payload: {
+        kind: PrNotifyEventKind;
+        title: string;
+        body: string;
+        url?: string;
+      },
+    ): boolean => {
       assertString(payload.title, "title");
       assertString(payload.body, "body");
       // Focus is judged against the window that asked, not the primary one:

--- a/electron/ipc/notifications.ts
+++ b/electron/ipc/notifications.ts
@@ -1,0 +1,33 @@
+import { ipcMain } from "electron";
+import { assertString } from "../ipc-validate";
+import { sendNotificationsUpdate } from "../notifications";
+import type { IpcDeps } from "./types";
+
+/**
+ * The durable notification log (ADR-162). Main owns the list; the renderer
+ * keeps a cache of it and never mutates its copy speculatively — every
+ * mutation here re-broadcasts the whole list through the single send-site in
+ * `../notifications`.
+ */
+export function register(deps: IpcDeps): void {
+  const { notificationStore } = deps;
+
+  const broadcast = () => sendNotificationsUpdate(deps.mainWindow);
+
+  ipcMain.handle("notifications:getAll", () => notificationStore.getAll());
+
+  ipcMain.handle("notifications:markRead", (_event, id: string) => {
+    assertString(id, "id");
+    if (notificationStore.markRead(id)) broadcast();
+  });
+
+  ipcMain.handle("notifications:markAllRead", () => {
+    notificationStore.markAllRead();
+    broadcast();
+  });
+
+  ipcMain.handle("notifications:clear", () => {
+    notificationStore.clear();
+    broadcast();
+  });
+}

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -10,6 +10,7 @@ import type { GitHubManager } from "../github";
 import type { LinearManager } from "../linear";
 import type { AgentHookServer } from "../agent-hooks";
 import type { TaskManager } from "../task-persistence";
+import type { NotificationStore } from "../notification-store";
 import type { PreferencesManager } from "../preferences";
 import type { KeybindingsManager } from "../keybindings";
 import type { WebviewServer } from "../webview-server";
@@ -46,6 +47,8 @@ export interface IpcDeps {
   linearManager: LinearManager;
   agentHookServer: AgentHookServer;
   taskManager: TaskManager;
+  /** ADR-162's durable notification log. */
+  notificationStore: NotificationStore;
   preferencesManager: PreferencesManager;
   keybindingsManager: KeybindingsManager;
   paneContextMap: Map<

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -1,8 +1,66 @@
-import { app, BrowserWindow, Notification, shell } from "electron";
+import { app, BrowserWindow, Notification } from "electron";
 import { execFile } from "node:child_process";
+import type {
+  NotificationKind,
+  NotificationRecord,
+  NotificationStore,
+  NotificationTarget,
+} from "./notification-store";
 import type { PreferencesManager } from "./preferences";
 import type { TaskInfo } from "./task-persistence";
 import type { AgentStatus } from "./terminal-host/types";
+
+/** Mirrors `PrNotifyEventKind` in `src/utils/pr-notifications.ts`. */
+export type PrNotifyEventKind =
+  | "comment"
+  | "approved"
+  | "changes-requested"
+  | "checks-failed";
+
+const PR_KIND_TO_NOTIFICATION_KIND: Record<PrNotifyEventKind, NotificationKind> = {
+  comment: "pr-comment",
+  approved: "pr-approved",
+  "changes-requested": "pr-changes-requested",
+  "checks-failed": "pr-checks-failed",
+};
+
+/**
+ * The durable notification log (ADR-162). Set once from app-lifecycle; absent
+ * in tests and in any context that never boots the app, where recording is
+ * simply skipped.
+ */
+let notificationStore: NotificationStore | null = null;
+
+export function setNotificationStore(store: NotificationStore | null): void {
+  notificationStore = store;
+}
+
+/**
+ * Broadcast the full notification list to the renderer. This is the single
+ * send-site for `notifications:changed`; do not call
+ * `webContents.send("notifications:changed", ...)` directly.
+ *
+ * The list is capped at 200 records, so shipping all of it on every mutation
+ * is deliberate — it makes renderer drift impossible (ADR-162 §3).
+ */
+export function sendNotificationsUpdate(mainWindow: BrowserWindow | null): void {
+  if (!notificationStore) return;
+  if (
+    !mainWindow ||
+    mainWindow.isDestroyed() ||
+    mainWindow.webContents.isDestroyed()
+  ) {
+    return;
+  }
+  try {
+    mainWindow.webContents.send(
+      "notifications:changed",
+      notificationStore.getAll(),
+    );
+  } catch {
+    // Render frame disposed — safe to ignore
+  }
+}
 
 export const unseenRespondedTasks = new Set<string>();
 export const unseenInputTasks = new Set<string>();
@@ -103,8 +161,24 @@ export function playNotificationSound(soundName: string | false): void {
 function presentNotification(
   mainWindow: BrowserWindow | null,
   preferencesManager: PreferencesManager,
-  opts: { title: string; body: string; onClick?: () => void },
+  opts: {
+    title: string;
+    body: string;
+    record: { kind: NotificationKind; target: NotificationTarget | null };
+  },
 ): boolean {
+  // Record *before* the focus check. A notification suppressed because the
+  // window was focused is exactly the case the log exists for (ADR-162 §2):
+  // the user may have been looking at a different pane the whole time.
+  const record: NotificationRecord | null =
+    notificationStore?.append({
+      kind: opts.record.kind,
+      title: opts.title,
+      body: opts.body,
+      target: opts.record.target,
+    }) ?? null;
+  sendNotificationsUpdate(mainWindow);
+
   if (!mainWindow || mainWindow.isDestroyed() || mainWindow.isFocused()) {
     return false;
   }
@@ -118,7 +192,11 @@ function presentNotification(
     if (!mainWindow || mainWindow.isDestroyed()) return;
     mainWindow.show();
     mainWindow.focus();
-    opts.onClick?.();
+    // One click path for banners and in-app rows alike: the renderer resolves
+    // the record's target through `navigateToNotification` (ADR-162 §4).
+    if (record) {
+      mainWindow.webContents.send("notifications:navigate", record.id);
+    }
   });
   notification.show();
   playNotificationSound(preferencesManager.get("notificationSound"));
@@ -133,18 +211,21 @@ export function maybeSendNotification(
   preferencesManager: PreferencesManager,
 ): void {
   let title: string;
+  let kind: NotificationKind;
   if (
     newStatus === "responded" &&
     prevStatus !== "responded" &&
     preferencesManager.get("notifyOnResponse")
   ) {
     title = "Agent responded";
+    kind = "agent-responded";
   } else if (
     newStatus === "requires_input" &&
     prevStatus !== "requires_input" &&
     preferencesManager.get("notifyOnRequiresInput")
   ) {
     title = "Agent needs input";
+    kind = "agent-requires-input";
   } else {
     return;
   }
@@ -152,8 +233,7 @@ export function maybeSendNotification(
   presentNotification(mainWindow, preferencesManager, {
     title,
     body: [task.name || "Agent", task.projectName].filter(Boolean).join(" — "),
-    onClick: () =>
-      mainWindow?.webContents.send("notification:navigate-to-task", task.id),
+    record: { kind, target: { type: "task", taskId: task.id } },
   });
 }
 
@@ -163,13 +243,16 @@ export function maybeSendNotification(
  * means the calling window is focused and the renderer should toast instead.
  */
 export function showPrNotification(
-  payload: { title: string; body: string; url?: string },
+  payload: { kind: PrNotifyEventKind; title: string; body: string; url?: string },
   mainWindow: BrowserWindow | null,
   preferencesManager: PreferencesManager,
 ): boolean {
   return presentNotification(mainWindow, preferencesManager, {
     title: payload.title,
     body: payload.body,
-    onClick: payload.url ? () => shell.openExternal(payload.url!) : undefined,
+    record: {
+      kind: PR_KIND_TO_NOTIFICATION_KIND[payload.kind] ?? "pr-comment",
+      target: payload.url ? { type: "url", url: payload.url } : null,
+    },
   });
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -455,10 +455,22 @@ contextBridge.exposeInMainWorld("electronAPI", {
   },
 
   notifications: {
-    onNavigateToTask: (callback: (taskId: string) => void) =>
-      onChannel("notification:navigate-to-task", callback),
-    show: (payload: { title: string; body: string; url?: string }) =>
-      ipcRenderer.invoke("notifications:show", payload) as Promise<boolean>,
+    show: (payload: {
+      kind: "comment" | "approved" | "changes-requested" | "checks-failed";
+      title: string;
+      body: string;
+      url?: string;
+    }) => ipcRenderer.invoke("notifications:show", payload) as Promise<boolean>,
+    getAll: () => ipcRenderer.invoke("notifications:getAll"),
+    markRead: (id: string) => ipcRenderer.invoke("notifications:markRead", id),
+    markAllRead: () => ipcRenderer.invoke("notifications:markAllRead"),
+    clear: () => ipcRenderer.invoke("notifications:clear"),
+    /** Main re-broadcasts the whole list on every mutation (ADR-162 §3). */
+    onChanged: (callback: (list: unknown[]) => void) =>
+      onChannel("notifications:changed", callback),
+    /** A native banner was clicked; the payload is the record id. */
+    onNavigate: (callback: (id: string) => void) =>
+      onChannel("notifications:navigate", callback),
   },
 
   clipboard: {

--- a/src/components/notifications/NotificationsPopover.module.css
+++ b/src/components/notifications/NotificationsPopover.module.css
@@ -1,0 +1,173 @@
+/* ── Bell trigger ── */
+
+.bellButton {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+}
+
+.badge {
+  position: absolute;
+  top: -3px;
+  right: -4px;
+  min-width: 12px;
+  height: 12px;
+  padding: 0 3px;
+  border-radius: 6px;
+  background: var(--red);
+  color: var(--bg, #000);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  font-weight: 600;
+  line-height: 12px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Popover ── */
+
+.popover {
+  /* Its own width: the sidebar is user-resizable and this must not follow it. */
+  width: 300px;
+  max-height: 420px;
+  display: flex;
+  flex-direction: column;
+  background: var(--dim);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 11px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.headerTitle {
+  flex: 1;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.headerAction {
+  font-size: 10px;
+}
+
+.scrollArea {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px;
+}
+
+.empty {
+  padding: 24px 6px;
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.6;
+  text-align: center;
+}
+
+/* ── Day groups — same visual language as TasksView ── */
+
+.dateGroup {
+  margin-bottom: 8px;
+}
+
+.dateGroupHeader {
+  display: flex;
+  align-items: center;
+  padding: 4px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  margin-bottom: 2px;
+}
+
+/* ── Rows ── */
+
+.row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-primary);
+}
+
+.row:hover {
+  background: var(--surface);
+}
+
+.rowRead {
+  color: var(--text-dim);
+}
+
+.rowIcon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--text-dim);
+}
+
+.iconAttention {
+  color: var(--yellow, #eab308);
+}
+
+.iconSuccess {
+  color: var(--green);
+}
+
+.iconError {
+  color: var(--red);
+}
+
+.rowText {
+  flex: 1;
+  min-width: 0;
+}
+
+.rowTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.rowRead .rowTitle {
+  font-weight: 400;
+}
+
+.rowBody {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-dim);
+  font-size: 10px;
+  margin-top: 1px;
+}
+
+.rowTime {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  margin-top: 1px;
+}
+
+.unreadDot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent, var(--blue, #3b82f6));
+  margin-top: 5px;
+}

--- a/src/components/notifications/NotificationsPopover.tsx
+++ b/src/components/notifications/NotificationsPopover.tsx
@@ -69,10 +69,11 @@ export function NotificationsPopover() {
             size="sm"
             className={styles.bellButton}
             aria-label="Notifications"
+            data-testid="notifications-bell"
           >
             <Bell size={12} />
             {unreadCount > 0 && (
-              <span className={styles.badge}>
+              <span className={styles.badge} data-testid="notifications-badge">
                 {unreadCount > 99 ? "99+" : unreadCount}
               </span>
             )}
@@ -82,9 +83,11 @@ export function NotificationsPopover() {
       <Popover.Portal>
         <Popover.Content
           className={styles.popover}
+          data-testid="notifications-popover"
           side="bottom"
           align="end"
           sideOffset={6}
+          collisionPadding={8}
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <div className={styles.header}>
@@ -109,7 +112,9 @@ export function NotificationsPopover() {
 
           <div className={styles.scrollArea}>
             {notifications.length === 0 && (
-              <div className={styles.empty}>Nothing here yet.</div>
+              <div className={styles.empty} data-testid="notifications-empty">
+                Nothing here yet.
+              </div>
             )}
 
             {BUCKET_ORDER.map((bucket) => {
@@ -126,6 +131,9 @@ export function NotificationsPopover() {
                       <div
                         key={record.id}
                         className={`${styles.row} ${record.read ? styles.rowRead : ""}`}
+                        data-testid="notification-row"
+                        data-kind={record.kind}
+                        data-read={record.read ? "true" : "false"}
                         role="button"
                         tabIndex={0}
                         onClick={() => handleRowClick(record)}

--- a/src/components/notifications/NotificationsPopover.tsx
+++ b/src/components/notifications/NotificationsPopover.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import * as Popover from "@radix-ui/react-popover";
+import Bell from "lucide-react/dist/esm/icons/bell";
+import Bot from "lucide-react/dist/esm/icons/bot";
+import CircleHelp from "lucide-react/dist/esm/icons/circle-help";
+import CircleCheck from "lucide-react/dist/esm/icons/circle-check";
+import CircleX from "lucide-react/dist/esm/icons/circle-x";
+import MessageSquare from "lucide-react/dist/esm/icons/message-square";
+import type { NotificationKind, NotificationRecord } from "../../electron.d";
+import { useNotificationStore } from "../../store/notification-store";
+import { navigateToNotification } from "../../utils/notification-navigation";
+import {
+  BUCKET_ORDER,
+  getDateBucket,
+  type DateBucket,
+} from "../../utils/date-buckets";
+import { relativeShortThenDate } from "../../utils/relative-time";
+import { Button } from "../ui/Button/Button";
+import { Tooltip } from "../ui/Tooltip/Tooltip";
+import styles from "./NotificationsPopover.module.css";
+
+const ICON_FOR: Record<NotificationKind, typeof Bell> = {
+  "agent-responded": Bot,
+  "agent-requires-input": CircleHelp,
+  "pr-comment": MessageSquare,
+  "pr-approved": CircleCheck,
+  "pr-changes-requested": CircleX,
+  "pr-checks-failed": CircleX,
+};
+
+const TONE_FOR: Partial<Record<NotificationKind, string>> = {
+  "agent-requires-input": styles.iconAttention,
+  "pr-approved": styles.iconSuccess,
+  "pr-changes-requested": styles.iconError,
+  "pr-checks-failed": styles.iconError,
+};
+
+/**
+ * The notification history (ADR-162 §6). Click-triggered rather than
+ * hover-triggered like `PrPopover`: this is something you deliberately open,
+ * not a badge you brush past.
+ */
+export function NotificationsPopover() {
+  const [open, setOpen] = useState(false);
+  const notifications = useNotificationStore((s) => s.notifications);
+  const unreadCount = useNotificationStore((s) => s.unreadCount);
+  const markAllRead = useNotificationStore((s) => s.markAllRead);
+  const clear = useNotificationStore((s) => s.clear);
+
+  const grouped = new Map<DateBucket, NotificationRecord[]>();
+  for (const record of notifications) {
+    const bucket = getDateBucket(record.timestamp);
+    const list = grouped.get(bucket);
+    if (list) list.push(record);
+    else grouped.set(bucket, [record]);
+  }
+
+  const handleRowClick = (record: NotificationRecord) => {
+    setOpen(false);
+    void navigateToNotification(record);
+  };
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Tooltip label="Notifications">
+        <Popover.Trigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={styles.bellButton}
+            aria-label="Notifications"
+          >
+            <Bell size={12} />
+            {unreadCount > 0 && (
+              <span className={styles.badge}>
+                {unreadCount > 99 ? "99+" : unreadCount}
+              </span>
+            )}
+          </Button>
+        </Popover.Trigger>
+      </Tooltip>
+      <Popover.Portal>
+        <Popover.Content
+          className={styles.popover}
+          side="bottom"
+          align="end"
+          sideOffset={6}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <div className={styles.header}>
+            <span className={styles.headerTitle}>Notifications</span>
+            <Button
+              variant="link"
+              className={styles.headerAction}
+              disabled={unreadCount === 0}
+              onClick={() => void markAllRead()}
+            >
+              Mark all read
+            </Button>
+            <Button
+              variant="link"
+              className={styles.headerAction}
+              disabled={notifications.length === 0}
+              onClick={() => void clear()}
+            >
+              Clear
+            </Button>
+          </div>
+
+          <div className={styles.scrollArea}>
+            {notifications.length === 0 && (
+              <div className={styles.empty}>Nothing here yet.</div>
+            )}
+
+            {BUCKET_ORDER.map((bucket) => {
+              const records = grouped.get(bucket);
+              if (!records) return null;
+
+              return (
+                <div key={bucket} className={styles.dateGroup}>
+                  <div className={styles.dateGroupHeader}>{bucket}</div>
+                  {records.map((record) => {
+                    const Icon = ICON_FOR[record.kind] ?? Bell;
+                    const tone = TONE_FOR[record.kind];
+                    return (
+                      <div
+                        key={record.id}
+                        className={`${styles.row} ${record.read ? styles.rowRead : ""}`}
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => handleRowClick(record)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handleRowClick(record);
+                          }
+                        }}
+                      >
+                        <Icon
+                          size={13}
+                          className={`${styles.rowIcon} ${tone ?? ""}`}
+                        />
+                        <div className={styles.rowText}>
+                          <div className={styles.rowTitle}>{record.title}</div>
+                          <div className={styles.rowBody}>{record.body}</div>
+                        </div>
+                        <span className={styles.rowTime}>
+                          {relativeShortThenDate(Date.parse(record.timestamp))}
+                        </span>
+                        {!record.read && <span className={styles.unreadDot} />}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/src/components/sidebar/Sidebar/Sidebar.module.css
+++ b/src/components/sidebar/Sidebar/Sidebar.module.css
@@ -69,6 +69,14 @@
   color: var(--text-dim);
 }
 
+.titlebarActions {
+  display: flex;
+  align-items: center;
+  margin-left: 4px;
+  flex-shrink: 0;
+  -webkit-app-region: no-drag;
+}
+
 .navControls {
   display: flex;
   align-items: center;

--- a/src/components/sidebar/Sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar/Sidebar.tsx
@@ -35,6 +35,7 @@ import { usePrWatcher } from "../../../hooks/usePrWatcher";
 import { ProjectItem } from "../ProjectItem";
 import { PortsList } from "../../ports/PortsList";
 import { TasksList } from "../TasksList";
+import { NotificationsPopover } from "../../notifications/NotificationsPopover";
 import styles from "./Sidebar.module.css";
 
 interface SidebarProps {
@@ -276,6 +277,9 @@ export function Sidebar(props: SidebarProps) {
               <ArrowRight size={12} />
             </Button>
           </Tooltip>
+        </div>
+        <div className={styles.titlebarActions}>
+          <NotificationsPopover />
         </div>
       </div>
       <div className={styles.content}>

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -50,6 +50,34 @@ export interface TaskInfo {
   resumedAt: string | null;
 }
 
+/**
+ * ADR-162's durable notification log. Mirrors `NotificationRecord` in
+ * `electron/notification-store.ts`; declared here rather than imported so the
+ * renderer's declaration surface stays self-contained.
+ */
+export type NotificationKind =
+  | "agent-responded"
+  | "agent-requires-input"
+  | "pr-comment"
+  | "pr-approved"
+  | "pr-changes-requested"
+  | "pr-checks-failed";
+
+export type NotificationTarget =
+  | { type: "task"; taskId: string }
+  | { type: "url"; url: string };
+
+export interface NotificationRecord {
+  id: string;
+  kind: NotificationKind;
+  title: string;
+  body: string;
+  /** ISO timestamp. */
+  timestamp: string;
+  read: boolean;
+  target: NotificationTarget | null;
+}
+
 export interface LinearTeam {
   id: string;
   name: string;
@@ -654,17 +682,28 @@ export interface ElectronAPI {
   };
 
   notifications: {
-    onNavigateToTask: (callback: (taskId: string) => void) => () => void;
     /**
      * Resolves `true` when a native notification was presented, `false` when
      * the calling window is focused — in which case the caller should show an
-     * in-app toast instead.
+     * in-app toast instead. Either way the event is recorded in the log.
      */
     show: (payload: {
+      kind: "comment" | "approved" | "changes-requested" | "checks-failed";
       title: string;
       body: string;
       url?: string;
     }) => Promise<boolean>;
+    /** Newest first. Main owns the list; the renderer only caches it. */
+    getAll: () => Promise<NotificationRecord[]>;
+    markRead: (id: string) => Promise<void>;
+    markAllRead: () => Promise<void>;
+    clear: () => Promise<void>;
+    /** Fires with the full list after every mutation (ADR-162 §3). */
+    onChanged: (
+      callback: (list: NotificationRecord[]) => void,
+    ) => () => void;
+    /** A native banner was clicked; the payload is the record id. */
+    onNavigate: (callback: (id: string) => void) => () => void;
   };
 
   clipboard: {

--- a/src/store/__tests__/notification-store.test.ts
+++ b/src/store/__tests__/notification-store.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NotificationRecord, TaskInfo } from "../../electron.d";
+
+// ── Mock electronAPI ──────────────────────────────────────────────────────────
+// Same pattern as task-store-unseen.test.ts: install the stub before importing
+// the store, so its eager init and its create-time subscriptions see it.
+
+let onChangedCallback: ((list: NotificationRecord[]) => void) | null = null;
+let onNavigateCallback: ((id: string) => void) | null = null;
+
+const notificationsApi = {
+  getAll: vi.fn().mockResolvedValue([] as NotificationRecord[]),
+  markRead: vi.fn().mockResolvedValue(undefined),
+  markAllRead: vi.fn().mockResolvedValue(undefined),
+  clear: vi.fn().mockResolvedValue(undefined),
+  show: vi.fn().mockResolvedValue(true),
+  onChanged: vi.fn((cb: (list: NotificationRecord[]) => void) => {
+    onChangedCallback = cb;
+    return () => {};
+  }),
+  onNavigate: vi.fn((cb: (id: string) => void) => {
+    onNavigateCallback = cb;
+    return () => {};
+  }),
+};
+
+const tasksApi = {
+  onUpdate: vi.fn(() => () => {}),
+  get: vi.fn().mockResolvedValue(null),
+  getActive: vi.fn().mockResolvedValue([]),
+  getAll: vi.fn().mockResolvedValue([]),
+  getUnseen: vi.fn().mockResolvedValue({ responded: [], requires_input: [] }),
+  markSeen: vi.fn().mockResolvedValue(undefined),
+};
+
+const shellApi = { openExternal: vi.fn().mockResolvedValue(undefined) };
+
+(window as unknown as { electronAPI: Record<string, unknown> }).electronAPI = {
+  ...((window as unknown as { electronAPI?: Record<string, unknown> }).electronAPI ?? {}),
+  tasks: tasksApi,
+  notifications: notificationsApi,
+  shell: shellApi,
+};
+
+const navigateToTask = vi.fn();
+vi.mock("../../utils/task-navigation", () => ({
+  navigateToTask: (task: TaskInfo) => navigateToTask(task),
+}));
+
+const { useNotificationStore } = await import("../notification-store");
+const { navigateToNotification } = await import(
+  "../../utils/notification-navigation"
+);
+const { useTaskStore } = await import("../task-store");
+
+function makeRecord(over: Partial<NotificationRecord> = {}): NotificationRecord {
+  return {
+    id: "n1",
+    kind: "agent-responded",
+    title: "Agent responded",
+    body: "Task — Project",
+    timestamp: "2024-01-15T00:00:00Z",
+    read: false,
+    target: null,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useNotificationStore.setState({
+    notifications: [],
+    unreadCount: 0,
+    loading: false,
+    loaded: true,
+  });
+});
+
+describe("useNotificationStore", () => {
+  it("replaces the list wholesale on a changed broadcast", () => {
+    useNotificationStore.setState({
+      notifications: [makeRecord({ id: "stale" })],
+      unreadCount: 1,
+    });
+
+    onChangedCallback?.([makeRecord({ id: "a" }), makeRecord({ id: "b" })]);
+
+    expect(useNotificationStore.getState().notifications.map((n) => n.id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("derives unreadCount from the broadcast list", () => {
+    onChangedCallback?.([
+      makeRecord({ id: "a", read: false }),
+      makeRecord({ id: "b", read: true }),
+      makeRecord({ id: "c", read: false }),
+    ]);
+
+    expect(useNotificationStore.getState().unreadCount).toBe(2);
+  });
+
+  it("routes a native click through the shared navigation helper", async () => {
+    onChangedCallback?.([
+      makeRecord({ id: "a", target: { type: "url", url: "https://x/pull/1" } }),
+    ]);
+
+    await onNavigateCallback?.("a");
+    // The helper awaits markRead before dispatching.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(shellApi.openExternal).toHaveBeenCalledWith("https://x/pull/1");
+  });
+
+  it("actions proxy straight to IPC — main is the writer", async () => {
+    await useNotificationStore.getState().markRead("a");
+    await useNotificationStore.getState().markAllRead();
+    await useNotificationStore.getState().clear();
+
+    expect(notificationsApi.markRead).toHaveBeenCalledWith("a");
+    expect(notificationsApi.markAllRead).toHaveBeenCalled();
+    expect(notificationsApi.clear).toHaveBeenCalled();
+    // No speculative local mutation: state only moves on the broadcast.
+    expect(useNotificationStore.getState().notifications).toEqual([]);
+  });
+});
+
+describe("navigateToNotification", () => {
+  it("opens a url target externally", async () => {
+    await navigateToNotification(
+      makeRecord({ target: { type: "url", url: "https://x/pull/2" } }),
+    );
+
+    expect(shellApi.openExternal).toHaveBeenCalledWith("https://x/pull/2");
+    expect(navigateToTask).not.toHaveBeenCalled();
+  });
+
+  it("resolves a task target from the task store", async () => {
+    const task = { id: "t1" } as TaskInfo;
+    useTaskStore.setState({ tasks: [task] });
+
+    await navigateToNotification(
+      makeRecord({ target: { type: "task", taskId: "t1" } }),
+    );
+
+    expect(navigateToTask).toHaveBeenCalledWith(task);
+    expect(tasksApi.get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to tasks.get when the task is not cached", async () => {
+    const task = { id: "t2" } as TaskInfo;
+    useTaskStore.setState({ tasks: [] });
+    tasksApi.get.mockResolvedValueOnce(task);
+
+    await navigateToNotification(
+      makeRecord({ target: { type: "task", taskId: "t2" } }),
+    );
+
+    expect(tasksApi.get).toHaveBeenCalledWith("t2");
+    expect(navigateToTask).toHaveBeenCalledWith(task);
+  });
+
+  it("marks read and stops when the target is null", async () => {
+    await navigateToNotification(makeRecord({ id: "n9", target: null }));
+
+    expect(notificationsApi.markRead).toHaveBeenCalledWith("n9");
+    expect(navigateToTask).not.toHaveBeenCalled();
+    expect(shellApi.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("does not re-mark an already-read record", async () => {
+    await navigateToNotification(makeRecord({ read: true, target: null }));
+
+    expect(notificationsApi.markRead).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/__tests__/setup.ts
+++ b/src/store/__tests__/setup.ts
@@ -31,9 +31,16 @@ if (typeof globalThis.window === "undefined") {
         getAll: vi.fn().mockResolvedValue([]),
         getUnseen: vi.fn().mockResolvedValue([]),
       },
-      // task-store.ts also subscribes to notifications.onNavigateToTask at init.
+      // notification-store.ts subscribes to onChanged/onNavigate and fetches
+      // the snapshot at module-init time (ADR-162).
       notifications: {
-        onNavigateToTask: vi.fn(() => vi.fn()),
+        getAll: vi.fn().mockResolvedValue([]),
+        markRead: vi.fn().mockResolvedValue(undefined),
+        markAllRead: vi.fn().mockResolvedValue(undefined),
+        clear: vi.fn().mockResolvedValue(undefined),
+        onChanged: vi.fn(() => vi.fn()),
+        onNavigate: vi.fn(() => vi.fn()),
+        show: vi.fn().mockResolvedValue(true),
       },
       // preferences-store.ts and keybindings-store.ts both read their state and
       // subscribe to changes at module-init time, so anything importing them

--- a/src/store/__tests__/task-store-pagination.test.ts
+++ b/src/store/__tests__/task-store-pagination.test.ts
@@ -24,7 +24,9 @@ const tasksApi = {
 };
 
 const notificationsApi = {
-  onNavigateToTask: vi.fn(),
+  getAll: vi.fn().mockResolvedValue([]),
+  onChanged: vi.fn(() => () => {}),
+  onNavigate: vi.fn(() => () => {}),
 };
 
 (window as unknown as { electronAPI: Record<string, unknown> }).electronAPI = {

--- a/src/store/__tests__/task-store-unseen.test.ts
+++ b/src/store/__tests__/task-store-unseen.test.ts
@@ -37,7 +37,9 @@ const tasksApi = {
 };
 
 const notificationsApi = {
-  onNavigateToTask: vi.fn(),
+  getAll: vi.fn().mockResolvedValue([]),
+  onChanged: vi.fn(() => () => {}),
+  onNavigate: vi.fn(() => () => {}),
 };
 
 (window as unknown as { electronAPI: Record<string, unknown> }).electronAPI = {

--- a/src/store/notification-store.ts
+++ b/src/store/notification-store.ts
@@ -1,0 +1,88 @@
+import { create } from "zustand";
+import type { NotificationRecord } from "../electron.d";
+import { navigateToNotification } from "../utils/notification-navigation";
+
+/**
+ * Renderer cache of main's notification log (ADR-162 §5).
+ *
+ * Main owns the list. Every mutation here is an IPC call whose effect arrives
+ * back through the `notifications:changed` broadcast — the renderer never
+ * mutates its copy speculatively, the same ownership split ADR-136 uses for
+ * the unseen sets.
+ */
+interface NotificationState {
+  /** Newest first, exactly as main sends it. */
+  notifications: NotificationRecord[];
+  loading: boolean;
+  loaded: boolean;
+  /** Derived from `notifications` on every set; never independent state. */
+  unreadCount: number;
+  markRead: (id: string) => Promise<void>;
+  markAllRead: () => Promise<void>;
+  clear: () => Promise<void>;
+}
+
+function countUnread(notifications: NotificationRecord[]): number {
+  return notifications.filter((n) => !n.read).length;
+}
+
+export const useNotificationStore = create<NotificationState>((set, get) => {
+  const api = window.electronAPI?.notifications;
+
+  api?.onChanged((list) => {
+    set({
+      notifications: list,
+      unreadCount: countUnread(list),
+      loaded: true,
+      loading: false,
+    });
+  });
+
+  // A native banner was clicked. Same destination resolution as an in-app row
+  // — one click path for both (ADR-162 §4).
+  api?.onNavigate(async (id) => {
+    let record = get().notifications.find((n) => n.id === id) ?? null;
+    if (!record) {
+      // The broadcast that carried this record may not have landed yet.
+      const list = await api.getAll().catch(() => [] as NotificationRecord[]);
+      set({ notifications: list, unreadCount: countUnread(list) });
+      record = list.find((n) => n.id === id) ?? null;
+    }
+    if (record) void navigateToNotification(record);
+  });
+
+  const init = async (): Promise<void> => {
+    if (!api) return;
+    try {
+      const list = await api.getAll();
+      set({
+        notifications: list,
+        unreadCount: countUnread(list),
+        loading: false,
+        loaded: true,
+      });
+    } catch {
+      set({ loading: false });
+    }
+  };
+  void init();
+
+  return {
+    notifications: [],
+    loading: true,
+    loaded: false,
+    unreadCount: 0,
+
+    markRead: async (id: string) => {
+      await window.electronAPI?.notifications.markRead(id);
+    },
+
+    markAllRead: async () => {
+      await window.electronAPI?.notifications.markAllRead();
+    },
+
+    clear: async () => {
+      await window.electronAPI?.notifications.clear();
+    },
+  };
+});

--- a/src/store/task-store.ts
+++ b/src/store/task-store.ts
@@ -49,18 +49,6 @@ export const useTaskStore = create<TaskState>((set, get) => {
     get().receiveTaskUpdate(task, unseen);
   });
 
-  // Navigate to task when a desktop notification is clicked
-  window.electronAPI?.notifications.onNavigateToTask(async (taskId) => {
-    const tasks = get().tasks;
-    let task = tasks.find((t) => t.id === taskId) ?? null;
-    if (!task) {
-      task = await window.electronAPI.tasks.get(taskId);
-    }
-    if (task) {
-      navigateToTask(task);
-    }
-  });
-
   // Paginated initial load: active tasks (full set, used by sidebar) +
   // the first page of all tasks (used by the history modal) + main's
   // unseen-flag snapshot (ADR-136 §"Change 3"). The three are merged so

--- a/src/utils/__tests__/pr-notifications.test.ts
+++ b/src/utils/__tests__/pr-notifications.test.ts
@@ -149,6 +149,7 @@ describe("deliverPrNotifications", () => {
     await flush();
 
     expect(show).toHaveBeenCalledWith({
+      kind: "comment",
       title: "PR #123 — new comment",
       body: "Add feature",
       url: "https://github.com/o/r/pull/123",

--- a/src/utils/__tests__/task-navigation.test.ts
+++ b/src/utils/__tests__/task-navigation.test.ts
@@ -27,7 +27,9 @@ vi.stubGlobal("window", {
       markSeen: markSeenMock,
     },
     notifications: {
-      onNavigateToTask: vi.fn(),
+      getAll: vi.fn().mockResolvedValue([]),
+  onChanged: vi.fn(() => () => {}),
+  onNavigate: vi.fn(() => () => {}),
     },
     projects: {
       select: vi.fn(),

--- a/src/utils/notification-navigation.ts
+++ b/src/utils/notification-navigation.ts
@@ -1,0 +1,34 @@
+import type { NotificationRecord } from "../electron.d";
+import { useNotificationStore } from "../store/notification-store";
+import { useTaskStore } from "../store/task-store";
+import { navigateToTask } from "./task-navigation";
+
+/**
+ * Resolve a notification to wherever it points. The single destination for
+ * both a clicked native banner and a clicked row in the notifications
+ * popover (ADR-162 §4) — two implementations of this is exactly the drift
+ * this consolidates.
+ */
+export async function navigateToNotification(
+  record: NotificationRecord,
+): Promise<void> {
+  if (!record.read) {
+    await useNotificationStore.getState().markRead(record.id);
+  }
+
+  const target = record.target;
+  if (!target) return;
+
+  if (target.type === "url") {
+    await window.electronAPI?.shell.openExternal(target.url);
+    return;
+  }
+
+  const tasks = useTaskStore.getState().tasks;
+  let task = tasks.find((t) => t.id === target.taskId) ?? null;
+  if (!task) {
+    task = (await window.electronAPI?.tasks.get(target.taskId)) ?? null;
+  }
+  // The task may have been pruned out from under the record; nothing to do.
+  if (task) navigateToTask(task);
+}

--- a/src/utils/pr-notifications.ts
+++ b/src/utils/pr-notifications.ts
@@ -90,6 +90,7 @@ async function notifyPrEvent(
   url: string,
 ): Promise<void> {
   const shown = await window.electronAPI.notifications.show({
+    kind: event.kind,
     title: event.title,
     body: event.body,
     url,

--- a/tests/e2e/notification-center.spec.ts
+++ b/tests/e2e/notification-center.spec.ts
@@ -1,0 +1,336 @@
+import fs from "fs";
+import path from "path";
+import { type ElectronApplication, type Page } from "@playwright/test";
+
+import {
+  createWorkspace,
+  expect,
+  importSeededProject,
+  killApp,
+  launchApp,
+  openTerminalTab,
+  test,
+} from "./fixtures";
+import { FAKE_AGENT } from "./helpers/fake-agent";
+import { Filmstrip } from "./helpers/filmstrip";
+import { activePaneId, awaitShellReady, runInTerminal } from "./helpers/terminal";
+
+/**
+ * ADR-162 end to end: what the app remembers about a notification, and what
+ * the bell in the sidebar does with it.
+ *
+ * The claim under test is not "a banner appears" — a test cannot see an OS
+ * banner, and the Electron window is focused for the whole run, which is
+ * precisely when Manor suppresses one. That is the point. Everything here
+ * asserts on the case the feature exists for: the notification nobody saw is
+ * still recorded, still readable, and still leads somewhere.
+ *
+ * Nothing reaches into main to fabricate a record. Agent notifications come
+ * from an agent reporting its own lifecycle over the hook endpoint; the PR
+ * notification comes from the same `notifications.show` call the PR watcher
+ * makes in the renderer.
+ */
+
+/** Where main persists the log — mirrors `notificationsFile()` in paths.ts. */
+function notificationsFile(tempHome: string): string {
+  const dataDir =
+    process.platform === "darwin"
+      ? path.join(tempHome, "Library", "Application Support", "Manor")
+      : path.join(tempHome, ".local", "share", "Manor");
+  return path.join(dataDir, "notifications.json");
+}
+
+function readPersistedTitles(tempHome: string): string[] {
+  const file = notificationsFile(tempHome);
+  if (!fs.existsSync(file)) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as {
+      notifications?: { title: string }[];
+    };
+    return (parsed.notifications ?? []).map((n) => n.title);
+  } catch {
+    // A read that lands mid-write sees half a file; the poll will come back.
+    return [];
+  }
+}
+
+const bell = (window: Page) => window.getByTestId("notifications-bell");
+const popover = (window: Page) => window.getByTestId("notifications-popover");
+const rows = (window: Page) => window.getByTestId("notification-row");
+
+async function openBell(window: Page): Promise<void> {
+  await bell(window).click();
+  await expect(popover(window)).toBeVisible({ timeout: 5_000 });
+}
+
+async function closeBell(window: Page): Promise<void> {
+  await window.keyboard.press("Escape");
+  await expect(popover(window)).not.toBeVisible({ timeout: 5_000 });
+}
+
+/**
+ * Ask main to notify, exactly as `usePrWatcher` → `notifyPrEvent` does.
+ *
+ * Resolves to whether a banner was presented. In a test it is always `false` —
+ * the window is focused — which is the interesting half: the record must exist
+ * anyway.
+ */
+function showPrNotification(
+  window: Page,
+  payload: { kind: string; title: string; body: string; url?: string },
+): Promise<boolean> {
+  return window.evaluate(
+    (p) =>
+      window.electronAPI.notifications.show(
+        p as Parameters<typeof window.electronAPI.notifications.show>[0],
+      ),
+    payload,
+  );
+}
+
+/**
+ * Put the window in the state the feature is about: focused, which is when
+ * main suppresses the banner. Focus is otherwise at the mercy of whatever
+ * else the machine running the suite has on screen.
+ */
+async function focusMainWindow(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    win?.show();
+    win?.focus();
+  });
+}
+
+/** Record every url main is asked to open, so a row click can be witnessed. */
+async function captureExternalOpens(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ shell }) => {
+    const opened: string[] = [];
+    (globalThis as unknown as { __openedUrls: string[] }).__openedUrls = opened;
+    shell.openExternal = async (url: string) => {
+      opened.push(url);
+    };
+  });
+}
+
+function openedUrls(app: ElectronApplication): Promise<string[]> {
+  return app.evaluate(
+    () => (globalThis as unknown as { __openedUrls?: string[] }).__openedUrls ?? [],
+  );
+}
+
+test.describe("notification center", () => {
+  test.setTimeout(180_000);
+
+  test("a suppressed notification is still recorded, readable, and clickable", async ({
+    app,
+    window,
+    tempHome,
+  }) => {
+    const film = new Filmstrip("notification-center");
+    await captureExternalOpens(app);
+    // The sidebar — and so the bell — only exists once a project does.
+    await importSeededProject(app, window, tempHome);
+
+    // The bell is there before anything has happened, and says nothing.
+    await expect(bell(window)).toBeVisible({ timeout: 30_000 });
+    await expect(window.getByTestId("notifications-badge")).toHaveCount(0);
+    await openBell(window);
+    await expect(window.getByTestId("notifications-empty")).toBeVisible();
+    await film.shot(window, "bell-empty");
+    await closeBell(window);
+
+    const url = "https://example.test/o/r/pull/7";
+    await focusMainWindow(app);
+    const presented = await showPrNotification(window, {
+      // The PR event kind the watcher emits; main maps it to a record kind.
+      kind: "approved",
+      title: "PR #7 approved",
+      body: "Add the notification center",
+      url,
+    });
+    // Focused window: main declined to show a banner. The whole feature is
+    // about what happens to the event now.
+    expect(presented).toBe(false);
+
+    await expect(window.getByTestId("notifications-badge")).toHaveText("1", {
+      timeout: 10_000,
+    });
+
+    await openBell(window);
+    await expect(rows(window)).toHaveCount(1);
+    const row = rows(window).first();
+    await expect(row).toHaveAttribute("data-kind", "pr-approved");
+    await expect(row).toHaveAttribute("data-read", "false");
+    await expect(row).toContainText("PR #7 approved");
+    await expect(row).toContainText("Add the notification center");
+    // Grouped by day, through the same bucketing the task list uses.
+    await expect(popover(window)).toContainText("Today");
+    await film.shot(window, "bell-unread-row");
+
+    // A click goes wherever the banner would have gone.
+    await row.click();
+    await expect(popover(window)).not.toBeVisible({ timeout: 5_000 });
+    await expect.poll(() => openedUrls(app), { timeout: 10_000 }).toContain(url);
+
+    // Clicking read it, and main — not the renderer — is what says so.
+    await expect(window.getByTestId("notifications-badge")).toHaveCount(0);
+    await openBell(window);
+    await expect(rows(window).first()).toHaveAttribute("data-read", "true");
+    await film.shot(window, "bell-row-read");
+    await closeBell(window);
+  });
+
+  test("mark all read and clear go through main", async ({ app, window, tempHome }) => {
+    await captureExternalOpens(app);
+    await importSeededProject(app, window, tempHome);
+    await expect(bell(window)).toBeVisible({ timeout: 30_000 });
+
+    for (const n of [1, 2, 3]) {
+      await showPrNotification(window, {
+        kind: "comment",
+        title: `PR #${n} — new comment`,
+        body: "Add the notification center",
+        url: `https://example.test/o/r/pull/${n}`,
+      });
+    }
+
+    await expect(window.getByTestId("notifications-badge")).toHaveText("3", {
+      timeout: 10_000,
+    });
+
+    await openBell(window);
+    await expect(rows(window)).toHaveCount(3);
+    // Newest first, as main sends them.
+    await expect(rows(window).first()).toContainText("PR #3");
+
+    await popover(window).getByRole("button", { name: "Mark all read" }).click();
+    await expect(window.getByTestId("notifications-badge")).toHaveCount(0, {
+      timeout: 10_000,
+    });
+    await expect(rows(window).nth(0)).toHaveAttribute("data-read", "true");
+    await expect(rows(window).nth(1)).toHaveAttribute("data-read", "true");
+    await expect(rows(window).nth(2)).toHaveAttribute("data-read", "true");
+
+    await popover(window).getByRole("button", { name: "Clear" }).click();
+    await expect(rows(window)).toHaveCount(0, { timeout: 10_000 });
+    await expect(window.getByTestId("notifications-empty")).toBeVisible();
+
+    // Cleared in main, not just in the view.
+    await expect
+      .poll(() => readPersistedTitles(tempHome), { timeout: 10_000 })
+      .toEqual([]);
+  });
+
+  /**
+   * Launches its own app instances rather than taking the fixture's: the
+   * fixture owns the shutdown of the app it created, and killing that one
+   * mid-test leaves its teardown holding a disposed handle.
+   */
+  test("the log survives a restart", async ({ tempHome }) => {
+    const first = await launchApp(tempHome);
+    try {
+      const window = await first.firstWindow();
+      await window.waitForLoadState("domcontentloaded");
+      await importSeededProject(first, window, tempHome);
+      await expect(bell(window)).toBeVisible({ timeout: 30_000 });
+
+      await showPrNotification(window, {
+        kind: "checks-failed",
+        title: "PR #12 — CI checks failing",
+        body: "Persisted across a restart",
+        url: "https://example.test/o/r/pull/12",
+      });
+
+      // Writes are debounced; wait for the record to actually be on disk
+      // rather than killing the app mid-timer and testing nothing.
+      await expect
+        .poll(() => readPersistedTitles(tempHome), { timeout: 15_000 })
+        .toContain("PR #12 — CI checks failing");
+    } finally {
+      await killApp(first);
+    }
+
+    const relaunched = await launchApp(tempHome);
+    try {
+      const window = await relaunched.firstWindow();
+      await window.waitForLoadState("domcontentloaded");
+
+      await expect(bell(window)).toBeVisible({ timeout: 30_000 });
+      // Unread state survives too — a missed notification stays missed.
+      await expect(window.getByTestId("notifications-badge")).toHaveText("1", {
+        timeout: 15_000,
+      });
+      await openBell(window);
+      await expect(rows(window)).toHaveCount(1);
+      await expect(rows(window).first()).toContainText(
+        "PR #12 — CI checks failing",
+      );
+    } finally {
+      await killApp(relaunched);
+    }
+  });
+
+  /**
+   * The agent path, end to end: a hook event moves a task's status, main
+   * records what it would have banner-ed, and the row shows up under the bell.
+   *
+   * The first park is deliberately not asserted on. A session whose *first*
+   * task-creating hook event is `requires_input` is created by the relay's
+   * `CreateTask` effect, which has never called `maybeSendNotification` — so
+   * there is no banner for it today, and therefore no record either. That gap
+   * is upstream of this ADR (which records where notifications are emitted,
+   * rather than changing when they fire). What follows drives the transitions
+   * a running agent actually produces.
+   */
+  test("an agent's status changes land in the log while the window is focused", async ({
+    app,
+    window,
+    tempHome,
+  }) => {
+    await importSeededProject(app, window, tempHome);
+    await createWorkspace(window, "notifications-e2e");
+    await openTerminalTab(window);
+
+    await awaitShellReady(window, tempHome, await activePaneId(window));
+    // Typed rather than launched with Cmd+N: that consumes the prewarmed
+    // session, whose task row has no pane and no project. See the e2e README.
+    await runInTerminal(window, `"${FAKE_AGENT}" notif-agent`);
+    await expect(bell(window)).toBeVisible();
+
+    // Answer the agent twice. Each reply is a Stop the relay turns into
+    // `responded`, and the window is focused throughout, so neither showed a
+    // banner. The log is the only trace, which is the point.
+    //
+    // (The agent parks in `requires_input` again after each reply, but the
+    // relay drops a re-park that arrives while the session is already
+    // `responded` — ADR-139's late-active guard. No banner today, so no
+    // record either.)
+    await runInTerminal(window, "hello");
+    await expect
+      .poll(() => readPersistedTitles(tempHome), { timeout: 90_000 })
+      .toEqual(["Agent responded"]);
+
+    await runInTerminal(window, "again");
+    // Two turns, two records. The unseen bit this sits alongside collapses a
+    // round trip into a single flag; the whole point of a log is that it does
+    // not.
+    await expect
+      .poll(() => readPersistedTitles(tempHome), { timeout: 90_000 })
+      .toEqual(["Agent responded", "Agent responded"]);
+
+    await expect(window.getByTestId("notifications-badge")).toHaveText("2", {
+      timeout: 15_000,
+    });
+    await openBell(window);
+
+    await expect(rows(window)).toHaveCount(2);
+    const respondedRow = rows(window).first();
+    await expect(respondedRow).toHaveAttribute("data-kind", "agent-responded");
+    await expect(respondedRow).toContainText("Agent responded");
+    // The body names the task and its project, exactly as the banner would.
+    await expect(respondedRow).toContainText("notif-agent");
+    await expect(respondedRow).toContainText("test-project");
+
+    await closeBell(window);
+  });
+});

--- a/tests/e2e/notification-center.spec.ts
+++ b/tests/e2e/notification-center.spec.ts
@@ -274,13 +274,10 @@ test.describe("notification center", () => {
    * The agent path, end to end: a hook event moves a task's status, main
    * records what it would have banner-ed, and the row shows up under the bell.
    *
-   * The first park is deliberately not asserted on. A session whose *first*
-   * task-creating hook event is `requires_input` is created by the relay's
-   * `CreateTask` effect, which has never called `maybeSendNotification` — so
-   * there is no banner for it today, and therefore no record either. That gap
-   * is upstream of this ADR (which records where notifications are emitted,
-   * rather than changing when they fire). What follows drives the transitions
-   * a running agent actually produces.
+   * The fake agent parks in `requires_input` on startup, which is the case the
+   * relay's `CreateTask` effect owns — no prior task exists for
+   * `UpdateTaskActiveStatus` to find — and then answers each message with a
+   * Stop. Both kinds of transition have to reach the log.
    */
   test("an agent's status changes land in the log while the window is focused", async ({
     app,
@@ -297,39 +294,46 @@ test.describe("notification center", () => {
     await runInTerminal(window, `"${FAKE_AGENT}" notif-agent`);
     await expect(bell(window)).toBeVisible();
 
-    // Answer the agent twice. Each reply is a Stop the relay turns into
-    // `responded`, and the window is focused throughout, so neither showed a
-    // banner. The log is the only trace, which is the point.
+    // The agent parks needing input before anything else happens. Focused
+    // window, so no banner — the record is the only trace, which is the point.
+    await expect
+      .poll(() => readPersistedTitles(tempHome), { timeout: 90_000 })
+      .toEqual(["Agent needs input"]);
+
+    // Answer it. The reply is a Stop the relay turns into `responded`.
     //
-    // (The agent parks in `requires_input` again after each reply, but the
-    // relay drops a re-park that arrives while the session is already
-    // `responded` — ADR-139's late-active guard. No banner today, so no
-    // record either.)
+    // (The agent parks again straight after, but the relay drops a re-park
+    // that arrives while the session is already `responded` — ADR-139's
+    // late-active guard. No banner for it, so no record either.)
     await runInTerminal(window, "hello");
     await expect
       .poll(() => readPersistedTitles(tempHome), { timeout: 90_000 })
-      .toEqual(["Agent responded"]);
+      .toEqual(["Agent responded", "Agent needs input"]);
 
     await runInTerminal(window, "again");
-    // Two turns, two records. The unseen bit this sits alongside collapses a
-    // round trip into a single flag; the whole point of a log is that it does
-    // not.
+    // Two turns, two `responded` records. The unseen bit this sits alongside
+    // collapses a round trip into a single flag; the whole point of a log is
+    // that it does not.
     await expect
       .poll(() => readPersistedTitles(tempHome), { timeout: 90_000 })
-      .toEqual(["Agent responded", "Agent responded"]);
+      .toEqual(["Agent responded", "Agent responded", "Agent needs input"]);
 
-    await expect(window.getByTestId("notifications-badge")).toHaveText("2", {
+    await expect(window.getByTestId("notifications-badge")).toHaveText("3", {
       timeout: 15_000,
     });
     await openBell(window);
 
-    await expect(rows(window)).toHaveCount(2);
+    await expect(rows(window)).toHaveCount(3);
     const respondedRow = rows(window).first();
     await expect(respondedRow).toHaveAttribute("data-kind", "agent-responded");
     await expect(respondedRow).toContainText("Agent responded");
     // The body names the task and its project, exactly as the banner would.
     await expect(respondedRow).toContainText("notif-agent");
     await expect(respondedRow).toContainText("test-project");
+
+    const inputRow = rows(window).last();
+    await expect(inputRow).toHaveAttribute("data-kind", "agent-requires-input");
+    await expect(inputRow).toContainText("Agent needs input");
 
     await closeBell(window);
   });


### PR DESCRIPTION
Closes #163. Implements [ADR-162](docs/decisions/adr-162-notification-center/index.md).

## What this is

Notifications in Manor were fire-and-forget. Miss the banner — app unfocused and it auto-dismissed, Do Not Disturb on, away from the machine — and the signal was gone. This adds a durable notification log owned by main, persisted to disk, cached by the renderer, and reachable from a bell in the sidebar titlebar.

The gap was widest exactly where the old design was most deliberate: a notification suppressed *because the window was focused* was never recorded anywhere, even though the user may have been looking at a different pane the whole time.

## The load-bearing decisions

**Recording happens inside `presentNotification`, before the focus early-return.** Recording at the two public entry points would work today and rot the first time someone adds a third. One site inside the function every native notification already passes through makes it structurally impossible to add a path that does not appear in the list — and gets the suppressed-because-focused case for free.

**One click path.** Task notifications used to send `notification:navigate-to-task`; PR notifications called `shell.openExternal` from main. Both collapse into a single `notifications:navigate` broadcast carrying the record id, resolved in the renderer by `navigateToNotification` — the same helper a click on a list row runs. The old channel and its preload binding are removed rather than left alongside; two navigation paths is the drift this consolidates.

**Main owns the list, and re-broadcasts all of it on every mutation.** The list is capped at 200 records, so a full-array broadcast costs nothing and removes the entire class of renderer-drift bugs that per-delta events invite. The renderer never mutates its copy speculatively — the same ownership split ADR-136 uses for the unseen sets.

Retention: 200 records or 30 days, whichever bites first. Constants, not a preference — deliberately deferred.

## A bug fixed along the way

An agent that asks for permission before doing anything else creates its task through the relay's `CreateTask` effect, and that branch never called `maybeSendNotification` — no prior task exists for `UpdateTaskActiveStatus` to find. The pulse appeared, the banner did not. The e2e run is what surfaced it. `CreateTask` now notifies with a null prior status, mirroring the update branch's unseen-then-notify-then-broadcast order.

## Relationship to the unseen sets

The list sits *alongside* the ADR-136 pulse indicators. They answer different questions: the pulse is per-task presence right now, the list is history. The dock badge stays driven by the unseen sets alone.

## Testing

- **4 e2e tests** (`tests/e2e/notification-center.spec.ts`), all asserting the case the feature exists for — the window is forced focused, so no banner is shown, and the record has to be there anyway. Suppressed-but-recorded with a working click-through; mark-all-read and clear; survival across a real app restart; and agent status changes driven through actual hook events from the fake agent. Records are checked on disk before they are checked in the popover, so a failure names the side of the IPC that broke.
- **3 relay unit tests** for the `CreateTask` fix.
- Renderer store tests covering broadcast replacement, `unreadCount` derivation, and task/url/null routing.

1610 unit tests and 21 e2e tests pass; `npm run build` clean. `tsc --noEmit` shows only the four errors that predate this branch (`electron/persistence.ts`, `layout-persistence.ts`, `app-store.test.ts`, `task-navigation.test.ts`).

## Worth knowing

- The sidebar — and so the bell — only renders once a project exists. Pre-existing `App.tsx` behaviour, not introduced here, but it means the bell is invisible on a fresh install.
- A re-park into `requires_input` immediately after a `Stop` is dropped by ADR-139's late-active guard, so it produces no banner and no record. Left alone deliberately; documented in the e2e test.
- The log is per-device. Nothing syncs, and the remote-control relay (ADR-161) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HwsT3FRd7FAuf1V4B47VF
